### PR TITLE
Rename EAF Search page title so to not reference LW

### DIFF
--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -220,7 +220,7 @@ addRoute([
     name: 'search',
     path: '/search',
     componentName: 'SearchPage',
-    title: 'LW Search'
+    title: 'Search'
   }
 ]);
 


### PR DESCRIPTION
This is a small correction to a page title. I show the mistake in the below screenshot of a Chrome tab.

<img width="226" alt="Screenshot 2020-06-09 at 21 22 07" src="https://user-images.githubusercontent.com/60350599/84196267-e3643400-aa97-11ea-85a9-5e6325a2846a.png">
