### PR TITLE
Add library route to occupy link from new recommendation section

### DIFF
--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -593,6 +593,11 @@ switch (forumTypeSetting.get()) {
         componentName: 'EASequencesHome'
       },
       {
+        name: 'eaSequencesRedirect',
+        path: '/library',
+        redirect: () => '/sequences'
+      },
+      {
         name: "TagsAll",
         path:'/tags',
         redirect: () => `/tags/all`,


### PR DESCRIPTION
The new Recommendations section has a link to /library in "Continue Reading". Make it redirect to /sequences.