### PR TITLE
Fixes after merge

### DIFF
--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -203,7 +203,6 @@ const RecommendationsAndCurated = ({
           <CoronavirusFrontpageWidget settings={frontpageRecommendationSettings} />
         </div>
       </AnalyticsContext> */}
-      {/* {!currentUser?.hideTaggingProgressBar && <TagProgressBar/>} */}
     </SingleColumnSection>
   }
   

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -203,7 +203,7 @@ const RecommendationsAndCurated = ({
           <CoronavirusFrontpageWidget settings={frontpageRecommendationSettings} />
         </div>
       </AnalyticsContext> */}
-      {!currentUser?.hideTaggingProgressBar && <TagProgressBar/>}
+      {/* {!currentUser?.hideTaggingProgressBar && <TagProgressBar/>} */}
     </SingleColumnSection>
   }
   

--- a/packages/lesswrong/components/tagging/AllTagsPage.tsx
+++ b/packages/lesswrong/components/tagging/AllTagsPage.tsx
@@ -15,6 +15,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import { wikiGradeDefinitions } from '../../lib/collections/tags/schema';
 import { useLocation } from '../../lib/routeUtil';
 import { useDialog } from '../common/withDialog';
+import { forumTypeSetting } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -120,7 +121,7 @@ const AllTagsPage = ({classes}: {
         </div>
         <AnalyticsContext pageSectionContext="tagDetails">
           <SectionTitle title={`Tag Details`}>
-            <Select
+            {forumTypeSetting.get() !== 'EAForum' && <Select
               value={wikiGrade||"none"}
               inputProps={{
                 name: 'Showing All Tags'
@@ -136,7 +137,7 @@ const AllTagsPage = ({classes}: {
                   {name}
                 </UntypedMenuItem>
               })}
-            </Select>
+            </Select>}
           </SectionTitle>
           <div>
             {results && results.map(tag => {

--- a/packages/lesswrong/components/tagging/WikiGradeDisplay.tsx
+++ b/packages/lesswrong/components/tagging/WikiGradeDisplay.tsx
@@ -3,6 +3,7 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { wikiGradeDefinitions } from '../../lib/collections/tags/schema';
 import StarIcon from '@material-ui/icons/Star';
 import { Link } from '../../lib/reactRouterWrapper';
+import { forumTypeSetting } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -22,7 +23,7 @@ const wikiGradeDescriptions = {
 
 const WikiGradeDisplay = ({wikiGrade, classes}: {wikiGrade:number, classes: any}) => {
   const { LWTooltip } = Components
-  if (wikiGrade === 0) return null
+  if (forumTypeSetting.get() === 'EAForum' || wikiGrade === 0) return null
   return <LWTooltip title={wikiGradeDescriptions[wikiGrade]}>
     <Link className={classes.root} to={"/tag/tag-grading-scheme"}>
       <StarIcon/>{wikiGradeDefinitions[wikiGrade]}

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -13,9 +13,10 @@ import withUser from '../common/withUser';
 import Tooltip from '@material-ui/core/Tooltip';
 import { postBodyStyles } from '../../themes/stylePiping'
 import {AnalyticsContext} from "../../lib/analyticsEvents";
-import { forumTypeSetting, hasEventsSetting } from '../../lib/instanceSettings';
+import { forumTypeSetting, hasEventsSetting, siteNameWithArticleSetting } from '../../lib/instanceSettings';
 import Typography from '@material-ui/core/Typography';
 import { separatorBulletStyles } from '../common/SectionFooter';
+import { taglineSetting } from '../common/HeadTags';
 
 export const sectionFooterLeftStyles = {
   flexGrow: 1,
@@ -175,7 +176,7 @@ class UsersProfileClass extends Component<UsersProfileProps,UsersProfileState> {
     const { slug, classes, currentUser, loading, results, location } = this.props;
     const { query } = location;
     const user = getUserFromResults(results)
-    const { SingleColumnSection, SectionTitle, SequencesNewButton, PostsListSettings, PostsList2, NewConversationButton, SubscribeTo, DialogGroup, SectionButton, SettingsButton, ContentItemBody, Loading, Error404, PermanentRedirect } = Components
+    const { SingleColumnSection, SectionTitle, SequencesNewButton, PostsListSettings, PostsList2, NewConversationButton, SubscribeTo, DialogGroup, SectionButton, SettingsButton, ContentItemBody, Loading, Error404, PermanentRedirect, HeadTags } = Components
     if (loading) {
       return <div className={classNames("page", "users-profile", classes.profilePage)}>
         <Loading/>
@@ -220,9 +221,13 @@ class UsersProfileClass extends Component<UsersProfileProps,UsersProfileState> {
     const currentShowLowKarma = (parseInt(query.karmaThreshold) !== DEFAULT_LOW_KARMA_THRESHOLD)
     
     const username = Users.getDisplayName(user)
+    const metaDescription = `${username}'s profile on ${siteNameWithArticleSetting.get()} — ${taglineSetting.get()}`
 
     return (
       <div className={classNames("page", "users-profile", classes.profilePage)}>
+        <HeadTags
+          description={metaDescription}
+        />
         <AnalyticsContext pageContext={"userPage"}>
           {/* Bio Section */}
           <SingleColumnSection>

--- a/packages/lesswrong/lib/betas.ts
+++ b/packages/lesswrong/lib/betas.ts
@@ -28,8 +28,8 @@ export const userHasEAHomeHandbook = adminOnly
 export const userCanCreateCommitMessages = moderatorOnly;
 
 // Shipped Features
-export const userCanManageTags = optInOnly;
-export const userCanCreateTags = optInOnly;
+export const userCanManageTags = shippedFeature;
+export const userCanCreateTags = shippedFeature;
 export const userCanUseTags = shippedFeature;
 export const userCanViewRevisionHistory = shippedFeature;
 export const userHasPingbacks = shippedFeature;

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -51,7 +51,6 @@ export const filters: Record<string,any> = {
       $lt: [
           {$size: 
               {$filter: {
-                  // ea-forum-look-here
                   // this was a hack during the Tagging Sprint, where we wanted people to tag posts with non-core-tags
                   input: {$objectToArray: "$tagRelevance"},
                   cond: {$not: {$in: ["$$this.k", ["xexCWMyds6QLWognu", "sYm3HiWcfZvrGu3ui", "izp6eeJJEg9v5zcur", "fkABsGCJZ6y9qConW", "Ng8Gice9KNkncxqcj", "MfpEPj6kJneT9gWT6", "3uE2pXvbcnS9nnZRE"]]}}

--- a/packages/lesswrong/lib/collections/users/recommendationSettings.ts
+++ b/packages/lesswrong/lib/collections/users/recommendationSettings.ts
@@ -28,8 +28,8 @@ const recommendationAlgorithmSettingsSchema = new SimpleSchema({
 
 const recommendationSettingsSchema = new SimpleSchema({
   frontpage: recommendationAlgorithmSettingsSchema,
+  frontpageEA: recommendationAlgorithmSettingsSchema,
   recommendationspage: recommendationAlgorithmSettingsSchema,
-  afterpost: recommendationAlgorithmSettingsSchema,
 });
 
 addFieldsDict(Users, {

--- a/packages/lesswrong/server/migrations/migrationUtils.ts
+++ b/packages/lesswrong/server/migrations/migrationUtils.ts
@@ -298,6 +298,12 @@ export async function forEachDocumentBatchInCollection({collection, batchSize, f
   loadFactor?: number
 })
 {
+  // As described in the docstring, we need to be able to query on the _id.
+  // Without this check, someone trying to use _id in the filter would overwrite
+  // this function's query and find themselves with an infinite loop.
+  if (filter && '_id' in filter) {
+    throw new Error('forEachDocumentBatchInCollection does not support filtering by _id')
+  }
   let rows = await collection.find({ ...filter },
     {
       sort: {_id: 1},

--- a/packages/lesswrong/server/scripts/exportPostDetails.ts
+++ b/packages/lesswrong/server/scripts/exportPostDetails.ts
@@ -88,7 +88,6 @@ Vulcan.exportPostDetails = wrapVulcanAsyncScript(
       const postUrl = siteUrlSetting.get()
       const row = {
         display_name: user.displayName,
-        email: user.email,
         id: post._id,
         user_id: post.userId,
         title: post.title,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1216,7 +1216,7 @@
     iterall "^1.1.3"
     uuid "^3.1.0"
 
-"@lesswrong/lesswrong-editor@./public/lesswrong-editor/":
+"@lesswrong/lesswrong-editor@./public/lesswrong-editor":
   version "0.1.1"
   dependencies:
     ckeditor5-math "^1.0.3"
@@ -7299,11 +7299,6 @@ mz@^2.7.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nan@^2.14.0:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
-  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
-
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -9837,11 +9832,6 @@ tr46@^1.0.1:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
-
-truncatise@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/truncatise/-/truncatise-0.0.7.tgz#3bd318341f1e5706dd50f0ed2d6205c3c83dbd54"
-  integrity sha512-d3Bkidq0A4udAYYOvTJzvUJdwOf9DqoHCDIaciO4Lr0eaLF4YjNp9qXAXlOzXEAqqnZDZ27LXZbU8hwLT3GtOw==
 
 ts-invariant@^0.4.0, ts-invariant@^0.4.4:
   version "0.4.4"


### PR DESCRIPTION
Some of these are just cleaning up small diffs that I stashed but didn't think were worth their own full PR, like the changes to migrationUtils.

For lack of a better time, in this PR I make the user pages have a meta description that's not just the generic site one.

I've disabled the progress bar completely. My guess is LW will comment out that line or delete it, at which point we'll no longer have the diff. However the wiki-grade feature is here to stay on LW, so I've made that change in such a way that I can submit upstream.

There may be some css changes coming, applied to the AllTags page through the eaThemes.ts file. That's blocked waiting on Aaron, but I thought I'd submit this now anyway.