### PR TITLE
Add ability to set image for social media preview

### DIFF
--- a/packages/lesswrong/components/form-components/ImageUpload.tsx
+++ b/packages/lesswrong/components/form-components/ImageUpload.tsx
@@ -13,13 +13,23 @@ const cloudinaryUploadPresetBannerSetting = new DatabasePublicSetting<string>('c
 const cloudinaryUploadPresetSocialPreviewSetting = new DatabasePublicSetting<string | null>('cloudinary.uploadPresetSocialPreview', null)
 
 const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+    marginTop: theme.spacing.unit,
+    "& img": {
+      display: "block",
+      marginBottom: 8,
+    },
+  },
   button: {
     background: "rgba(0,0,0, 0.5)",
     "&:hover": {
       background: "rgba(0,0,0,.35)"
     },
     color: "white",
-  }
+  },
+  imageIcon: {
+    marginRight: theme.spacing.unit
+  },
 });
 
 const cloudinaryArgsByImageType = {
@@ -36,12 +46,27 @@ const cloudinaryArgsByImageType = {
     cropping_default_selection_ratio: 3,
     upload_preset: cloudinaryUploadPresetBannerSetting.get(),
   },
-  socialPreviewImage: {
+  socialPreviewImageId: {
     min_image_height: 400,
     min_image_width: 700,
     cropping_aspect_ratio: 1.91,
     cropping_default_selection_ratio: 3,
     upload_preset: cloudinaryUploadPresetSocialPreviewSetting.get(),
+  },
+}
+
+const formPreviewSizeByImageType = {
+  gridImageId: {
+    width: 203,
+    height: 80
+  },
+  bannerImageId: {
+    width: "auto",
+    height: 380
+  },
+  socialPreviewImageId: {
+    width: 153,
+    height: 80
   },
 }
 
@@ -89,27 +114,28 @@ class ImageUpload extends Component<any,any> {
     }, this.setImageInfo);
   }
   render(){
-    const { classes } = this.props;
+    const { classes, name, label } = this.props;
+    const formPreviewSize = formPreviewSizeByImageType[name]
+    if (!formPreviewSize) throw new Error("Unsupported image upload type")
+    console.log('ImageUploadSpacewardRender8')
     
     return (
-      <div className="upload">
+      <div className={classes.root}>
         <Helmet>
           <script src="https://widget.cloudinary.com/global/all.js" type="text/javascript"/>
           <script src='//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js'/>
         </Helmet>
-        <div className="image-upload-description">{this.props.label}</div>
         {this.state.imageId &&
           <Components.CloudinaryImage
             publicId={this.state.imageId}
-            width={this.props.name == "gridImageId" ? "203" : "auto"}
-            height={this.props.name == "bannerImageId" ? "380" : "80"}
+            {...formPreviewSize}
           /> }
         <Button
           onClick={this.uploadWidget}
           className={classNames("image-upload-button", classes.button)}
         >
-          <ImageIcon/>
-          {this.state.imageId ? `Replace ${this.props.label}` : `Upload ${this.props.label}`}
+          <ImageIcon className={classes.imageIcon}/>
+          {this.state.imageId ? `Replace ${label}` : `Upload ${label}`}
         </Button>
       </div>
     );

--- a/packages/lesswrong/components/form-components/ImageUpload.tsx
+++ b/packages/lesswrong/components/form-components/ImageUpload.tsx
@@ -102,7 +102,6 @@ class ImageUpload extends Component<any,any> {
   uploadWidget = () => {
     const cloudinaryArgs = cloudinaryArgsByImageType[this.props.name]
     if (!cloudinaryArgs) throw new Error("Unsupported image upload type")
-    console.log("ImageUpload -> uploadWidget -> cloudinaryArgs", cloudinaryArgs)
     // @ts-ignore
     cloudinary.openUploadWidget({
       cropping: "server",
@@ -117,7 +116,6 @@ class ImageUpload extends Component<any,any> {
     const { classes, name, label } = this.props;
     const formPreviewSize = formPreviewSizeByImageType[name]
     if (!formPreviewSize) throw new Error("Unsupported image upload type")
-    console.log('ImageUploadSpacewardRender8')
     
     return (
       <div className={classes.root}>

--- a/packages/lesswrong/components/form-components/ImageUpload.tsx
+++ b/packages/lesswrong/components/form-components/ImageUpload.tsx
@@ -10,6 +10,7 @@ import { cloudinaryCloudNameSetting, DatabasePublicSetting } from '../../lib/pub
 
 const cloudinaryUploadPresetGridImageSetting = new DatabasePublicSetting<string>('cloudinary.uploadPresetGridImage', 'tz0mgw2s')
 const cloudinaryUploadPresetBannerSetting = new DatabasePublicSetting<string>('cloudinary.uploadPresetBanner', 'navcjwf7')
+const cloudinaryUploadPresetSocialPreviewSetting = new DatabasePublicSetting<string | null>('cloudinary.uploadPresetSocialPreview', null)
 
 const styles = (theme: ThemeType): JssStyles => ({
   button: {
@@ -20,6 +21,29 @@ const styles = (theme: ThemeType): JssStyles => ({
     color: "white",
   }
 });
+
+const cloudinaryArgsByImageType = {
+  gridImageId: {
+    min_image_height: 80,
+    min_image_width: 203,
+    cropping_aspect_ratio: 2.5375,
+    upload_preset: cloudinaryUploadPresetGridImageSetting.get(),
+  },
+  bannerImageId: {
+    min_image_height: 380,
+    min_image_width: 1600,
+    cropping_aspect_ratio: 2.5375,
+    cropping_default_selection_ratio: 3,
+    upload_preset: cloudinaryUploadPresetBannerSetting.get(),
+  },
+  socialPreviewImage: {
+    min_image_height: 400,
+    min_image_width: 700,
+    cropping_aspect_ratio: 1.91,
+    cropping_default_selection_ratio: 3,
+    upload_preset: cloudinaryUploadPresetSocialPreviewSetting.get(),
+  },
+}
 
 class ImageUpload extends Component<any,any> {
   constructor(props, context) {
@@ -51,31 +75,17 @@ class ImageUpload extends Component<any,any> {
   }
 
   uploadWidget = () => {
-    let min_image_height, min_image_width, cropping_aspect_ratio, cropping_default_selection_ratio, upload_preset;
-    if (this.props.name == "gridImageId") {
-      min_image_height = 80;
-      min_image_width = 203;
-      cropping_aspect_ratio = 2.5375;
-      upload_preset = cloudinaryUploadPresetGridImageSetting.get();
-    } else if (this.props.name == "bannerImageId") {
-      min_image_height = 380;
-      min_image_width = 1600;
-      cropping_aspect_ratio = 2.5375;
-      cropping_default_selection_ratio = 3;
-      upload_preset = cloudinaryUploadPresetBannerSetting.get()
-    }
+    const cloudinaryArgs = cloudinaryArgsByImageType[this.props.name]
+    if (!cloudinaryArgs) throw new Error("Unsupported image upload type")
+    console.log("ImageUpload -> uploadWidget -> cloudinaryArgs", cloudinaryArgs)
     // @ts-ignore
-    cloudinary.openUploadWidget(
-      {cropping: "server",
+    cloudinary.openUploadWidget({
+      cropping: "server",
       cloud_name: cloudinaryCloudNameSetting.get(),
-      upload_preset,
       theme: 'minimal',
-      min_image_height,
-      min_image_width,
       cropping_validate_dimension: true,
       cropping_show_dimensions: true,
-      cropping_default_selection_ratio,
-      cropping_aspect_ratio
+      ...cloudinaryArgs
     }, this.setImageInfo);
   }
   render(){

--- a/packages/lesswrong/components/notifications/NotificationTypeSettings.tsx
+++ b/packages/lesswrong/components/notifications/NotificationTypeSettings.tsx
@@ -81,4 +81,3 @@ declare global {
     NotificationTypeSettings: typeof NotificationTypeSettingsComponent
   }
 }
-

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -143,12 +143,15 @@ class PostsPage extends Component<PostsPageProps> {
       const description = this.getDescription(post)
       const ogUrl = Posts.getPageUrl(post, true) // open graph
       const canonicalUrl = post.canonicalSource || ogUrl
+      const socialPreviewImageUrl = `https://res.cloudinary.com/cea/image/upload/${post.socialPreviewImageId}`
+      console.log("PostsPage -> render -> socialPreviewImageUrl", socialPreviewImageUrl)
+      // console.log("PostsPage -> render -> post.socialPreviewImageId", post.socialPreviewImageId)
 
       return (
           <AnalyticsContext pageContext="postsPage" postId={post._id}>
             <div className={classNames(classes.root, {[classes.tocActivated]: !!sectionData})}>
               <HeadTags
-                ogUrl={ogUrl} canonicalUrl={canonicalUrl}
+                ogUrl={ogUrl} canonicalUrl={canonicalUrl} image={socialPreviewImageUrl}
                 title={post.title} description={description} noIndex={post.noIndex || !!commentId}
               />
               {/* Header/Title */}

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -144,8 +144,6 @@ class PostsPage extends Component<PostsPageProps> {
       const ogUrl = Posts.getPageUrl(post, true) // open graph
       const canonicalUrl = post.canonicalSource || ogUrl
       const socialPreviewImageUrl = `https://res.cloudinary.com/cea/image/upload/${post.socialPreviewImageId}`
-      console.log("PostsPage -> render -> socialPreviewImageUrl", socialPreviewImageUrl)
-      // console.log("PostsPage -> render -> post.socialPreviewImageId", post.socialPreviewImageId)
 
       return (
           <AnalyticsContext pageContext="postsPage" postId={post._id}>

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -143,7 +143,7 @@ class PostsPage extends Component<PostsPageProps> {
       const description = this.getDescription(post)
       const ogUrl = Posts.getPageUrl(post, true) // open graph
       const canonicalUrl = post.canonicalSource || ogUrl
-      const socialPreviewImageUrl = `https://res.cloudinary.com/cea/image/upload/${post.socialPreviewImageId}`
+      const socialPreviewImageUrl = post?.socialPreviewImageId && `https://res.cloudinary.com/cea/image/upload/c_fill,ar_1.91,g_auto/${post.socialPreviewImageId}`
 
       return (
           <AnalyticsContext pageContext="postsPage" postId={post._id}>

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -143,7 +143,7 @@ class PostsPage extends Component<PostsPageProps> {
       const description = this.getDescription(post)
       const ogUrl = Posts.getPageUrl(post, true) // open graph
       const canonicalUrl = post.canonicalSource || ogUrl
-      const socialPreviewImageUrl = post?.socialPreviewImageId && `https://res.cloudinary.com/cea/image/upload/c_fill,ar_1.91,g_auto/${post.socialPreviewImageId}`
+      const socialPreviewImageUrl = post.socialPreviewImageUrl
 
       return (
           <AnalyticsContext pageContext="postsPage" postId={post._id}>

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -143,6 +143,7 @@ class PostsPage extends Component<PostsPageProps> {
       const description = this.getDescription(post)
       const ogUrl = Posts.getPageUrl(post, true) // open graph
       const canonicalUrl = post.canonicalSource || ogUrl
+      // For imageless posts this will be an empty string
       const socialPreviewImageUrl = post.socialPreviewImageUrl
 
       return (

--- a/packages/lesswrong/components/sequenceEditor/EditSequenceTitle.tsx
+++ b/packages/lesswrong/components/sequenceEditor/EditSequenceTitle.tsx
@@ -6,11 +6,11 @@ import { sequencesImageScrim } from '../sequences/SequencesPage'
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
-    marginTop: 65,
+    marginTop: 90, // TODO: get from global
     backgroundColor: "rgba(0,0,0,0.25)",
     height: 380,
     [theme.breakpoints.down('sm')]: {
-      marginTop: 40,
+      marginTop: 79,
     }
   },
   imageScrim: {

--- a/packages/lesswrong/components/sequenceEditor/EditSequenceTitle.tsx
+++ b/packages/lesswrong/components/sequenceEditor/EditSequenceTitle.tsx
@@ -32,6 +32,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     overflow: 'hidden',
     '&::placeholder': {
       color: 'rgba(255,255,255,.5)'
+    },
+    [theme.breakpoints.down('sm')]: {
+      left: 5,
     }
   }
 });
@@ -66,4 +69,3 @@ declare global {
     EditSequenceTitle: typeof EditSequenceTitleComponent
   }
 }
-

--- a/packages/lesswrong/lib/collections/posts/collection.ts
+++ b/packages/lesswrong/lib/collections/posts/collection.ts
@@ -46,6 +46,7 @@ interface ExtendedPostsCollection extends PostsCollection {
   getFacebookShareUrl: (post: DbPost) => string
   getEmailShareUrl: (post: DbPost) => string
   getPageUrl: (post: PostsMinimumForGetPageUrl, isAbsolute?: boolean, sequenceId?: string|null) => string
+  getSocialPreviewImage: (post: DbPost) => string
   getCommentCount: (post: PostsBase|DbPost) => number
   getCommentCountStr: (post: PostsBase|DbPost, commentCount?: number|undefined) => string
   getLastCommentedAt: (post: PostsBase|DbPost) => Date

--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -325,11 +325,22 @@ addFieldsDict(Posts, {
   socialPreviewImageId: {
     type: String,
     optional: true,
+    label: "Social Preview Image",
+    viewableBy: ['guests'],
+    editableBy: ['sunshineRegiment', 'admins'],
+    insertableBy: ['sunshineRegiment', 'admins'],
+    control: "ImageUpload",
+    group: formGroups.advancedOptions,
+  },
+  
+  socialPreviewImageUrl: {
+    type: String,
+    optional: true,
+    hidden: true,
+    label: "Social Preview Image URL",
     viewableBy: ['guests'],
     editableBy: ['members'],
     insertableBy: ['members'],
-    control: "ImageUpload",
-    group: formGroups.advancedOptions,
   },
 
   canonicalSequenceId: {

--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -333,11 +333,12 @@ addFieldsDict(Posts, {
     group: formGroups.advancedOptions,
   },
   
-  socialPreviewImageUrl: {
+  // Autoset OpenGraph image, derived from the first post image in a callback
+  socialPreviewImageAutoUrl: {
     type: String,
     optional: true,
     hidden: true,
-    label: "Social Preview Image URL",
+    label: "Social Preview Image Auto-generated URL",
     viewableBy: ['guests'],
     editableBy: ['members'],
     insertableBy: ['members'],

--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -61,7 +61,6 @@ export const formGroups = {
     name: "advancedOptions",
     label: "Options",
     startCollapsed: true,
-    flexStyle: true
   },
   highlight: {
     order: 21,

--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -321,6 +321,17 @@ addFieldsDict(Posts, {
     foreignKey: 'Users',
     optional: true
   },
+  
+  // Cloudinary image id for an image that will be used as the OpenGraph image
+  socialPreviewImageId: {
+    type: String,
+    optional: true,
+    viewableBy: ['guests'],
+    editableBy: ['members'],
+    insertableBy: ['members'],
+    control: "ImageUpload",
+    group: formGroups.advancedOptions,
+  },
 
   canonicalSequenceId: {
     ...foreignKeyField({

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -46,7 +46,7 @@ registerFragment(`
     canonicalCollectionSlug
     curatedDate
     commentsLocked
-    socialPreviewImageId
+    socialPreviewImageUrl
 
     # questions
     question

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -46,6 +46,7 @@ registerFragment(`
     canonicalCollectionSlug
     curatedDate
     commentsLocked
+    socialPreviewImageId
 
     # questions
     question

--- a/packages/lesswrong/lib/collections/posts/helpers.ts
+++ b/packages/lesswrong/lib/collections/posts/helpers.ts
@@ -109,14 +109,14 @@ ${Posts.getLink(post, true, false)}
   return `mailto:?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
 };
 
-// TODO;
+// Select the social preview image for the post, using the manually-set
+// cloudinary image if available, or the auto-set from the post contents. If
+// neither of those are available, it will return null.
 Posts.getSocialPreviewImage = (post: DbPost): string => {
   const manualId = post.socialPreviewImageId
-  console.log("manualId", manualId)
-  if (manualId) return manualId
+  if (manualId) return `https://res.cloudinary.com/cea/image/upload/c_fill,ar_1.91,g_auto/${manualId}`
   const autoUrl = post.socialPreviewImageAutoUrl
-  console.log("autoUrl", autoUrl)
-  return autoUrl
+  return autoUrl || ''
 }
 
 

--- a/packages/lesswrong/lib/collections/posts/helpers.ts
+++ b/packages/lesswrong/lib/collections/posts/helpers.ts
@@ -109,6 +109,16 @@ ${Posts.getLink(post, true, false)}
   return `mailto:?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
 };
 
+// TODO;
+Posts.getSocialPreviewImage = (post: DbPost): string => {
+  const manualId = post.socialPreviewImageId
+  console.log("manualId", manualId)
+  if (manualId) return manualId
+  const autoUrl = post.socialPreviewImageAutoUrl
+  console.log("autoUrl", autoUrl)
+  return autoUrl
+}
+
 
 // @summary Get URL of a post page.
 Posts.getPageUrl = function(post: PostsMinimumForGetPageUrl, isAbsolute=false, sequenceId:string|null=null): string {

--- a/packages/lesswrong/lib/collections/posts/schema.ts
+++ b/packages/lesswrong/lib/collections/posts/schema.ts
@@ -323,6 +323,12 @@ const schema: SchemaType<DbPost> = {
     viewableBy: ['guests'],
     resolver: (post: DbPost, args: void, context: ResolverContext) => Posts.getFacebookShareUrl(post),
   }),
+  
+  socialPreviewImageUrl: resolverOnlyField({
+    type: String,
+    viewableBy: ['guests'],
+    resolver: (post: DbPost, args: void, context: ResolverContext) => Posts.getSocialPreviewImage(post)
+  }),
 
   question: {
     type: Boolean,

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -490,6 +490,7 @@ interface DbPost extends DbObject {
   collectionTitle: string
   coauthorUserIds: Array<string>
   socialPreviewImageId: string
+  socialPreviewImageAutoUrl: string
   canonicalSequenceId: string
   canonicalCollectionSlug: string
   canonicalBookId: string

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -489,6 +489,7 @@ interface DbPost extends DbObject {
   frontpageDate: Date
   collectionTitle: string
   coauthorUserIds: Array<string>
+  socialPreviewImageId: string
   canonicalSequenceId: string
   canonicalCollectionSlug: string
   canonicalBookId: string

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -70,6 +70,7 @@ interface PostsBase extends PostsMinimumInfo { // fragment on Posts
   readonly canonicalCollectionSlug: string,
   readonly curatedDate: Date,
   readonly commentsLocked: boolean,
+  readonly socialPreviewImageId: string,
   readonly question: boolean,
   readonly hiddenRelatedQuestion: boolean,
   readonly originalPostRelationSourceId: string,
@@ -165,6 +166,7 @@ interface PostsList_contents { // fragment on Revisions
 }
 
 interface PostsListTag extends PostsList { // fragment on Posts
+  readonly tagRelevance: any /*{"definitions":[{}]}*/,
   readonly tagRel: WithVoteTagRel|null,
 }
 
@@ -541,6 +543,13 @@ interface lwEventsAdminPageFragment { // fragment on LWEvents
 interface emailHistoryFragment { // fragment on LWEvents
   readonly _id: string,
   readonly userId: string,
+  readonly name: string,
+  readonly properties: any /*{"definitions":[{"blackbox":true}]}*/,
+}
+
+interface gatherTownEventFragment { // fragment on LWEvents
+  readonly _id: string,
+  readonly createdAt: Date,
   readonly name: string,
   readonly properties: any /*{"definitions":[{"blackbox":true}]}*/,
 }
@@ -1159,7 +1168,6 @@ interface UsersEdit extends UsersProfile { // fragment on Users
   readonly hideFrontpageMap: boolean,
   readonly hideTaggingProgressBar: boolean,
   readonly deleted: boolean,
-  readonly hideWalledGardenUI: boolean,
 }
 
 interface unclaimedReportsList { // fragment on Reports
@@ -1409,6 +1417,17 @@ interface TagRelFragment extends TagRelBasicInfo { // fragment on TagRels
   readonly tag: TagPreviewFragment|null,
   readonly post: PostsList|null,
   readonly currentUserVotes: Array<VoteFragment>,
+}
+
+interface TagRelCreationFragment extends TagRelBasicInfo { // fragment on TagRels
+  readonly tag: TagPreviewFragment|null,
+  readonly post: TagRelCreationFragment_post|null,
+  readonly currentUserVotes: Array<VoteFragment>,
+}
+
+interface TagRelCreationFragment_post extends PostsList { // fragment on Posts
+  readonly tagRelevance: any /*{"definitions":[{}]}*/,
+  readonly tagRel: WithVoteTagRel|null,
 }
 
 interface TagRelMinimumFragment extends TagRelBasicInfo { // fragment on TagRels
@@ -1685,6 +1704,7 @@ interface FragmentTypes {
   LWEventsDefaultFragment: LWEventsDefaultFragment
   lwEventsAdminPageFragment: lwEventsAdminPageFragment
   emailHistoryFragment: emailHistoryFragment
+  gatherTownEventFragment: gatherTownEventFragment
   TagFlagFragment: TagFlagFragment
   TagFlagEditFragment: TagFlagEditFragment
   TagFlagsDefaultFragment: TagFlagsDefaultFragment
@@ -1745,6 +1765,7 @@ interface FragmentTypes {
   SuggestAlignmentUser: SuggestAlignmentUser
   TagRelBasicInfo: TagRelBasicInfo
   TagRelFragment: TagRelFragment
+  TagRelCreationFragment: TagRelCreationFragment
   TagRelMinimumFragment: TagRelMinimumFragment
   WithVoteTagRel: WithVoteTagRel
   TagBasicInfo: TagBasicInfo

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -70,7 +70,7 @@ interface PostsBase extends PostsMinimumInfo { // fragment on Posts
   readonly canonicalCollectionSlug: string,
   readonly curatedDate: Date,
   readonly commentsLocked: boolean,
-  readonly socialPreviewImageId: string,
+  readonly socialPreviewImageUrl: string,
   readonly question: boolean,
   readonly hiddenRelatedQuestion: boolean,
   readonly originalPostRelationSourceId: string,

--- a/packages/lesswrong/server/callbacks/postCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/postCallbacks.ts
@@ -197,16 +197,17 @@ async function extractSocialPreviewImage (post: DbPost) {
 
   let socialPreviewImageAutoUrl: null | string = null
   if (post.contents?.html) {
-    console.log(`extractSocialPreviewImage`, 'found html')
     const $ = cheerio.load(post.contents.html)
     const firstImg = $('img').first()
     if (firstImg) {
-      console.log(`extractSocialPreviewImage`, 'found firstImg')
       socialPreviewImageAutoUrl = firstImg.attr('src') || null
     }
   }
-  console.log(`extractSocialPreviewImage`, 'socialPreviewImageUrl', socialPreviewImageAutoUrl)
   
+  // Side effect is necessary, as edit.async does not run a db update with the
+  // returned value
+  // It's important to run this regardless of whether or not we found an image,
+  // as removing an image should remove the social preview for that image
   Posts.update({ _id: post._id }, {$set: { socialPreviewImageAutoUrl }})
   
   return {...post, socialPreviewImageAutoUrl}

--- a/packages/lesswrong/server/callbacks/postCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/postCallbacks.ts
@@ -190,22 +190,26 @@ async function updatedPostMaybeTriggerReview (newPost, oldPost) {
 }
 addCallback("posts.edit.async", updatedPostMaybeTriggerReview);
 
+// Use the first image in the post as the social preview image
 async function extractSocialPreviewImage (post: DbPost) {
-  let socialPreviewImageUrl: null | string = null
+  // socialPreviewImageId is set manually, and will override this
+  if (post.socialPreviewImageId) return post
+
+  let socialPreviewImageAutoUrl: null | string = null
   if (post.contents?.html) {
     console.log(`extractSocialPreviewImage`, 'found html')
     const $ = cheerio.load(post.contents.html)
     const firstImg = $('img').first()
     if (firstImg) {
       console.log(`extractSocialPreviewImage`, 'found firstImg')
-      socialPreviewImageUrl = firstImg.attr('src') || null
+      socialPreviewImageAutoUrl = firstImg.attr('src') || null
     }
   }
-  console.log(`extractSocialPreviewImage`, 'socialPreviewImageUrl', socialPreviewImageUrl)
+  console.log(`extractSocialPreviewImage`, 'socialPreviewImageUrl', socialPreviewImageAutoUrl)
   
-  Posts.update({ _id: post._id }, {$set: { socialPreviewImageUrl }})
+  Posts.update({ _id: post._id }, {$set: { socialPreviewImageAutoUrl }})
   
-  return {...post, socialPreviewImageUrl}
+  return {...post, socialPreviewImageAutoUrl}
   
 }
 

--- a/packages/lesswrong/styles/_sequences.scss
+++ b/packages/lesswrong/styles/_sequences.scss
@@ -91,18 +91,18 @@
       margin-bottom: 0em;
     }
     .form-input.input-bannerImageId {
-      margin-top:65px;
+      margin-top:90px;  // Match Forum header
       position: absolute !important;
       left:0;
       max-width:100%;
 
       @include mui-breakpoint-down-sm {
-        margin-top:40px;
+        margin-top:79px;  // Match Forum header
         padding:0;
       }
       .form-input-errors {
         position:absolute;
-        top:45px;
+        top:84px;
         left:7px;
         text-align: left;
       }

--- a/packages/lesswrong/styles/_sequences.scss
+++ b/packages/lesswrong/styles/_sequences.scss
@@ -5,13 +5,6 @@
   padding: 5px;
 }
 
-.input-bannerImageId .image-upload-description {
-  display:none;
-}
-
-.input-gridImageId .image-upload-description {
-  display:none;
-}
 .input-bannerImageId .image-upload-button {
   position:absolute !important;
   left:15px;
@@ -97,14 +90,6 @@
     .editor.content-body {
       margin-bottom: 0em;
     }
-    .input-gridImageId {
-      margin-bottom:15px;
-
-      img {
-        display:block;
-        margin-bottom:15px;
-      }
-    }
     .form-input.input-bannerImageId {
       margin-top:65px;
       position: absolute !important;
@@ -114,9 +99,6 @@
       @include mui-breakpoint-down-sm {
         margin-top:40px;
         padding:0;
-      }
-      .image-upload-description {
-        display:none;
       }
       .form-input-errors {
         position:absolute;


### PR DESCRIPTION
Add a field to the Posts schema that stores the cloudinary ID of a user-uploaded image for the social media preview.

In Vulcan-style, we include in our schema that it should be controlled by the ImageUpload component. Annoyingly, most of the work in this otherwise-simple PR was fixing the styling.

While I was working on ImageUpload styling, I needed to both reference, and make sure I didn't break, the styling from the sequences edit page. And in doing so noticed some areas for improvement.