### PR TITLE
Hot fix:  Fix hub link in footer

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationFooterItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationFooterItem.tsx
@@ -55,9 +55,15 @@ const styles = (theme: ThemeType): JssStyles => ({
 const TabNavigationFooterItem = ({tab, classes}) => {
   const { TabNavigationSubItem } = Components
   const { pathname } = useLocation()
+  // React router links don't handle external URLs, so use a
+  // normal HTML a tag if the URL is external
+  const externalLink = /https?:\/\//.test(tab.link);
+  const Element = externalLink ? 
+    ({to, ...rest}) => <a href={to} target="_blank" rel="noopener noreferrer" {...rest} />
+    : Link;
 
   return <Tooltip placement='top' title={tab.tooltip || ''}>
-    <Link
+    <Element
       to={tab.link}
       className={classNames(classes.navButton, {[classes.selected]: pathname === tab.link})}
     >
@@ -75,7 +81,7 @@ const TabNavigationFooterItem = ({tab, classes}) => {
           { tab.mobileTitle || tab.title }
         </span>
       }
-    </Link>
+    </Element>
   </Tooltip>
 }
 


### PR DESCRIPTION
This applies the same fix I did in `TabNavigationItem`  to `TabNavigationFooterItem`.

@jpaddison3 I assume this is worthy of a hot fix but feel free to close if you disagree.

To test: make your browser window small enough that you see the menu as footer items, and then click on the EA hub link.