### PR TITLE
Tiny title fix

### DIFF
--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -253,7 +253,7 @@ addRoute(
     name: 'allTags',
     path: '/tags/all',
     componentName: 'AllTagsPage',
-    title: "Concepts Portal",
+    title: "Tags Portal",
   },
   {
     name: "Concepts",


### PR DESCRIPTION
Shows up as the title of the page on the browser tab. Currently it's using LW's term for the page.