### PR TITLE
Remove header spacing override for Layout

### DIFF
--- a/packages/lesswrong/themes/eaTheme.ts
+++ b/packages/lesswrong/themes/eaTheme.ts
@@ -154,13 +154,6 @@ const theme = createLWTheme({
         padding: ".7rem",
       }
     },
-    Layout: {
-      main: {
-        '@media (max-width: 959.95px)': {
-          marginTop: 36,
-        }
-      }
-    },
     Header: {
       root: {
         height: 90,


### PR DESCRIPTION
Now that headers are better about reporting their true size, it's not needed, and was causing an unwanted small grey background.