### PR TITLE
Duplicate email fix fix

### DIFF
--- a/packages/lesswrong/server/migrations/2021-07-22-fixDuplicateEmails.ts
+++ b/packages/lesswrong/server/migrations/2021-07-22-fixDuplicateEmails.ts
@@ -28,7 +28,8 @@ registerMigration({
         user.id,
         user.displayName,
         array_agg(posts.id) as postIds,
-        array_agg(comments.id) as commentIds
+        array_agg(comments.id) as commentIds,
+        array_agg(emails.address) as arrayEmail
       from users
       left join posts on users.id = posts.userId
       left join comments on users.id = comments.userId

--- a/packages/lesswrong/server/migrations/2021-07-22-fixDuplicateEmails.ts
+++ b/packages/lesswrong/server/migrations/2021-07-22-fixDuplicateEmails.ts
@@ -37,7 +37,7 @@ registerMigration({
     const userInfo: Array<MongoDuplicateUser> = await Users.aggregate([
       {
         '$match': {
-          'deleted': false
+          '$or': [ {'deleted': false}, {'deleted': {'$exists': false}} ]
         }
       },
       {

--- a/packages/lesswrong/server/scripts/fixDuplicateEmail.tests.ts
+++ b/packages/lesswrong/server/scripts/fixDuplicateEmail.tests.ts
@@ -30,7 +30,7 @@ describe("mergeSingleUser", () => {
     expect(results).toStrictEqual(expected);
   });
   
-  it("handles only one good user who doesn't have any mail", () => {
+  it("handles only one good user who doesn't have an email", () => {
     const userList = [
       { '_id': '1', posts: [], comments: [], matches: { arrayEmail: ['foo'] }  },
       { '_id': '2', posts: [{ '_id': '1' }], comments: [] },

--- a/packages/lesswrong/server/scripts/fixDuplicateEmail.tests.ts
+++ b/packages/lesswrong/server/scripts/fixDuplicateEmail.tests.ts
@@ -29,6 +29,19 @@ describe("mergeSingleUser", () => {
     const results = mergeSingleUser(userList)
     expect(results).toStrictEqual(expected);
   });
+  
+  it("handles only one good user who doesn't have any mail", () => {
+    const userList = [
+      { '_id': '1', posts: [], comments: [], matches: { arrayEmail: ['foo'] }  },
+      { '_id': '2', posts: [{ '_id': '1' }], comments: [] },
+      { '_id': '3', posts: [], comments: [] }]
+    const expected = {
+      type: 'ManualMergeAction',
+      sourceIds: ['1', '2', '3']
+    }
+    const results = mergeSingleUser(userList)
+    expect(results).toStrictEqual(expected);
+  });
 
 
   it("handles no good users", async () => {
@@ -40,6 +53,21 @@ describe("mergeSingleUser", () => {
       type: 'RunnableMergeAction',
       destinationId: '1',
       sourceIds: ['2', '3'],
+      justification: 'all empty accounts'
+    }
+    const results = mergeSingleUser(userList)
+    expect(results).toStrictEqual(expected);
+  });
+  
+  it("handles no good users but one has an email", async () => {
+    const userList = [
+      { '_id': '1', posts: [], comments: [] },
+      { '_id': '2', posts: [], comments: [], matches: { arrayEmail: ['foo'] }  },
+      { '_id': '3', posts: [], comments: [] }]
+    const expected = {
+      type: 'RunnableMergeAction',
+      destinationId: '2',
+      sourceIds: ['1', '3'],
       justification: 'all empty accounts'
     }
     const results = mergeSingleUser(userList)
@@ -69,6 +97,21 @@ describe("mergeSingleUser", () => {
       type: 'RunnableMergeAction',
       destinationId: '1',
       sourceIds: ['2', '3'],
+      justification: 'all accounts share the same name'
+    }
+    const results = mergeSingleUser(userList)
+    expect(results).toStrictEqual(expected);
+  });
+
+  it("handles finding the one with a email array", async () => {
+    const userList = [
+      { '_id': '1', posts: [{ '_id': '1' }], comments: [], matches: { displayName: "Test Name" } },
+      { '_id': '2', posts: [], comments: [{ '_id': '1' }], matches: { displayName: "test_name", arrayEmail: ['foo'] } },
+      { '_id': '3', posts: [], comments: [] }]
+    const expected = {
+      type: 'RunnableMergeAction',
+      destinationId: '2',
+      sourceIds: ['1', '3'],
       justification: 'all accounts share the same name'
     }
     const results = mergeSingleUser(userList)

--- a/packages/lesswrong/server/scripts/mergeAccounts.ts
+++ b/packages/lesswrong/server/scripts/mergeAccounts.ts
@@ -108,6 +108,16 @@ Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string) => {
   // Transfer localgroups
   await transferCollection({sourceUserId, targetUserId, collectionName: "Localgroups"})
   
+  // Transfer votes that target content from source user (authorId)
+  // eslint-disable-next-line no-console
+  console.log("Transferring votes that target source user")
+  await Votes.update({authorId: sourceUserId}, {$set: {authorId: targetUserId}}, {multi: true})
+
+  // Transfer votes cast by source user
+  // eslint-disable-next-line no-console
+  console.log("Transferring votes cast by source user")
+  await Votes.update({userId: sourceUserId}, {$set: {userId: targetUserId}}, {multi: true})
+
   // Transfer karma
   // eslint-disable-next-line no-console
   console.log("Transferring karma")
@@ -123,16 +133,6 @@ Vulcan.mergeAccounts = async (sourceUserId: string, targetUserId: string) => {
     },
     validate: false
   })
-  
-  // Transfer votes that target content from source user (authorId)
-  // eslint-disable-next-line no-console
-  console.log("Transferring votes that target source user")
-  await Votes.update({authorId: sourceUserId}, {$set: {authorId: targetUserId}}, {multi: true})
-
-  // Transfer votes cast by source user
-  // eslint-disable-next-line no-console
-  console.log("Transferring votes cast by source user")
-  await Votes.update({userId: sourceUserId}, {$set: {userId: targetUserId}}, {multi: true})
   
   // Change slug of source account by appending "old" and reset oldSlugs array
   // eslint-disable-next-line no-console


### PR DESCRIPTION
Fix to #168

1. Recalculate karma after transferring votes, not before
2. set the destination user to be the user with something in the email address array, if one exists
3. Include users  where deleted is null, not just where it's false

We still have one user [who claimed](https://app.intercom.com/a/apps/xycbzvda/inbox/inbox/3705107/conversations/69456500011050) that their account was deactivated after running this script. Both Aaron and I think that their account is activated, and I'm confused what's happening here. I haven't received any response from them in a business week though, so I'm inclined to move ahead.