### PR TITLE
Forum Digest Subscription

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,6 +191,7 @@
     "mathjax": "^2.7.5",
     "mathjax-node": "^2.1.1",
     "mathjax-node-page": "3.2.0",
+    "md5": "^2.3.0",
     "mingo": "^2.2.11",
     "moment": "^2.22.2",
     "mongodb": "^3.6.3",

--- a/packages/lesswrong/lib/collections/users/helpers.ts
+++ b/packages/lesswrong/lib/collections/users/helpers.ts
@@ -284,7 +284,7 @@ interface UserLocation {
 // for server-side rendering, but we can try to get a location client-side
 // using the browser geolocation API. (This won't necessarily work, since not
 // all browsers and devices support it, and it requires user permission.)
-export const userGetLocation = (currentUser: UsersCurrent|null): UserLocation => {
+export const userGetLocation = (currentUser: UsersCurrent|DbUser|null): UserLocation => {
   const placeholderLat = 37.871853;
   const placeholderLng = -122.258423;
 

--- a/packages/lesswrong/lib/publicSettings.ts
+++ b/packages/lesswrong/lib/publicSettings.ts
@@ -82,3 +82,6 @@ export const elicitSourceURL = new DatabasePublicSetting('elicitSourceURL', 'htt
 export const elicitSourceId = new DatabasePublicSetting('elicitSourceId', 'XCjOpumu-')
 
 export const mapboxAPIKeySetting = new DatabasePublicSetting<string | null>('mapbox.apiKey', null) // API Key for the mapbox map and tile requests
+
+export const mailchimpAPIKeySetting = new DatabasePublicSetting<string | null>('mailchimp.apiKey', null)
+export const mailchimpForumDigestListIdSetting = new DatabasePublicSetting<string | null>('mailchimp.forumDigestListId', null)

--- a/packages/lesswrong/lib/publicSettings.ts
+++ b/packages/lesswrong/lib/publicSettings.ts
@@ -85,3 +85,4 @@ export const mapboxAPIKeySetting = new DatabasePublicSetting<string | null>('map
 
 export const mailchimpAPIKeySetting = new DatabasePublicSetting<string | null>('mailchimp.apiKey', null)
 export const mailchimpForumDigestListIdSetting = new DatabasePublicSetting<string | null>('mailchimp.forumDigestListId', null)
+export const mailchimpEAForumListIdSetting = new DatabasePublicSetting<string | null>('mailchimp.eaForumListId', null)

--- a/packages/lesswrong/server/callbacks/userCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/userCallbacks.ts
@@ -15,6 +15,7 @@ import { sendVerificationEmail } from "../vulcan-lib/apollo-server/authenticatio
 import { forumTypeSetting } from "../../lib/instanceSettings";
 import { mailchimpAPIKeySetting, mailchimpEAForumListIdSetting, mailchimpForumDigestListIdSetting } from "../../lib/publicSettings";
 import { userGetLocation } from "../../lib/collections/users/helpers";
+import { captureException } from "@sentry/core";
 
 const MODERATE_OWN_PERSONAL_THRESHOLD = 50
 const TRUSTLEVEL1_THRESHOLD = 2000
@@ -233,6 +234,8 @@ getCollectionHooks("Users").editAsync.add(async function subscribeToForumDigest 
       'Content-Type': 'application/json',
       Authorization: `API_KEY ${mailchimpAPIKey}`,
     },
+  }).catch(e => {
+    captureException(e);
   });
 });
 
@@ -264,5 +267,7 @@ getCollectionHooks("Users").newAsync.add(async function subscribeToDripCampaign(
       'Content-Type': 'application/json',
       Authorization: `API_KEY ${mailchimpAPIKey}`,
     },
+  }).catch(e => {
+    captureException(e);
   });
 });

--- a/packages/lesswrong/server/callbacks/userCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/userCallbacks.ts
@@ -244,6 +244,7 @@ getCollectionHooks("Users").editAsync.add(async function subscribeToForumDigest 
     },
   }).catch(e => {
     captureException(e);
+    // eslint-disable-next-line no-console
     console.log(e);
   });
 });
@@ -283,6 +284,7 @@ getCollectionHooks("Users").newAsync.add(async function subscribeToEAForumAudien
     },
   }).catch(e => {
     captureException(e);
+    // eslint-disable-next-line no-console
     console.log(e);
   });
 });

--- a/packages/lesswrong/server/callbacks/userCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/userCallbacks.ts
@@ -210,6 +210,9 @@ getCollectionHooks("Users").editAsync.add(async function subscribeToForumDigest 
 
   const mailchimpAPIKey = mailchimpAPIKeySetting.get();
   const mailchimpForumDigestListId = mailchimpForumDigestListIdSetting.get();
+  if (!mailchimpAPIKey || !mailchimpForumDigestListId) {
+    return;
+  }
   const { lat: latitude, lng: longitude } = userGetLocation(newUser);
   const status = newUser.subscribedToDigest ? 'subscribed' : 'unsubscribed';   
   await fetch(`https://us8.api.mailchimp.com/3.0/lists/${mailchimpForumDigestListId}/members`, {
@@ -239,6 +242,9 @@ getCollectionHooks("Users").newAsync.add(async function subscribeToDripCampaign(
   }
   const mailchimpAPIKey = mailchimpAPIKeySetting.get();
   const mailchimpEAForumListId = mailchimpEAForumListIdSetting.get();
+  if (!mailchimpAPIKey || !mailchimpEAForumListId) {
+    return;
+  }
   const { lat: latitude, lng: longitude } = userGetLocation(user);
   await fetch(`https://us8.api.mailchimp.com/3.0/lists/${mailchimpEAForumListId}/members`, {
     method: 'POST',

--- a/packages/lesswrong/server/callbacks/userCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/userCallbacks.ts
@@ -233,6 +233,9 @@ getCollectionHooks("Users").editAsync.add(async function subscribeToForumDigest 
         latitude,
         longitude,
       }}),
+      merge_fields: {
+        FNAME: newUser.displayName,
+      },
       status,
     }),
     headers: {

--- a/packages/lesswrong/server/callbacks/userCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/userCallbacks.ts
@@ -229,9 +229,6 @@ getCollectionHooks("Users").editAsync.add(async function subscribeToForumDigest 
         latitude,
         longitude,
       }}),
-      merge_fields: {
-        FNAME: newUser.fullName
-      },
       status,
     }),
     headers: {
@@ -262,9 +259,6 @@ getCollectionHooks("Users").newAsync.add(async function subscribeToDripCampaign(
         latitude,
         longitude,
       }}),
-      merge_fields: {
-        FNAME: user.fullName
-      },
       status: "subscribed",
     }),
     headers: {

--- a/packages/lesswrong/server/callbacks/userCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/userCallbacks.ts
@@ -1,4 +1,5 @@
 import fetch from "node-fetch";
+import md5 from "md5";
 import Users from "../../lib/collections/users/collection";
 import { userGetGroups } from '../../lib/vulcan-users/permissions';
 import { updateMutator } from '../vulcan-lib/mutators';
@@ -216,8 +217,11 @@ getCollectionHooks("Users").editAsync.add(async function subscribeToForumDigest 
   }
   const { lat: latitude, lng: longitude, known } = userGetLocation(newUser);
   const status = newUser.subscribedToDigest ? 'subscribed' : 'unsubscribed'; 
-  void fetch(`https://us8.api.mailchimp.com/3.0/lists/${mailchimpForumDigestListId}/members`, {
-    method: 'POST',
+  
+  const emailHash = md5(newUser.email.toLowerCase());
+
+  void fetch(`https://us8.api.mailchimp.com/3.0/lists/${mailchimpForumDigestListId}/members/${emailHash}`, {
+    method: 'PUT',
     body: JSON.stringify({
       email_address: newUser.email,
       email_type: 'html', 

--- a/packages/lesswrong/server/callbacks/userCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/userCallbacks.ts
@@ -241,6 +241,7 @@ getCollectionHooks("Users").editAsync.add(async function subscribeToForumDigest 
     },
   }).catch(e => {
     captureException(e);
+    console.log(e);
   });
 });
 
@@ -279,5 +280,6 @@ getCollectionHooks("Users").newAsync.add(async function subscribeToEAForumAudien
     },
   }).catch(e => {
     captureException(e);
+    console.log(e);
   });
 });

--- a/packages/lesswrong/server/callbacks/userCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/userCallbacks.ts
@@ -215,7 +215,7 @@ getCollectionHooks("Users").editAsync.add(async function subscribeToForumDigest 
   }
   const { lat: latitude, lng: longitude, known } = userGetLocation(newUser);
   const status = newUser.subscribedToDigest ? 'subscribed' : 'unsubscribed'; 
-  await fetch(`https://us8.api.mailchimp.com/3.0/lists/${mailchimpForumDigestListId}/members`, {
+  void fetch(`https://us8.api.mailchimp.com/3.0/lists/${mailchimpForumDigestListId}/members`, {
     method: 'POST',
     body: JSON.stringify({
       email_address: newUser.email,
@@ -246,7 +246,7 @@ getCollectionHooks("Users").newAsync.add(async function subscribeToDripCampaign(
     return;
   }
   const { lat: latitude, lng: longitude, known } = userGetLocation(user);
-  await fetch(`https://us8.api.mailchimp.com/3.0/lists/${mailchimpEAForumListId}/members`, {
+  void fetch(`https://us8.api.mailchimp.com/3.0/lists/${mailchimpEAForumListId}/members`, {
     method: 'POST',
     body: JSON.stringify({
       email_address: user.email,

--- a/packages/lesswrong/server/callbacks/userCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/userCallbacks.ts
@@ -213,17 +213,17 @@ getCollectionHooks("Users").editAsync.add(async function subscribeToForumDigest 
   if (!mailchimpAPIKey || !mailchimpForumDigestListId) {
     return;
   }
-  const { lat: latitude, lng: longitude } = userGetLocation(newUser);
-  const status = newUser.subscribedToDigest ? 'subscribed' : 'unsubscribed';   
+  const { lat: latitude, lng: longitude, known } = userGetLocation(newUser);
+  const status = newUser.subscribedToDigest ? 'subscribed' : 'unsubscribed'; 
   await fetch(`https://us8.api.mailchimp.com/3.0/lists/${mailchimpForumDigestListId}/members`, {
     method: 'POST',
     body: JSON.stringify({
       email_address: newUser.email,
       email_type: 'html', 
-      location: {
+      ...(known && {location: {
         latitude,
         longitude,
-      },
+      }}),
       merge_fields: {
         FNAME: newUser.fullName
       },
@@ -245,16 +245,16 @@ getCollectionHooks("Users").newAsync.add(async function subscribeToDripCampaign(
   if (!mailchimpAPIKey || !mailchimpEAForumListId) {
     return;
   }
-  const { lat: latitude, lng: longitude } = userGetLocation(user);
+  const { lat: latitude, lng: longitude, known } = userGetLocation(user);
   await fetch(`https://us8.api.mailchimp.com/3.0/lists/${mailchimpEAForumListId}/members`, {
     method: 'POST',
     body: JSON.stringify({
       email_address: user.email,
       email_type: 'html', 
-      location: {
+      ...(known && {location: {
         latitude,
         longitude,
-      },
+      }}),
       merge_fields: {
         FNAME: user.fullName
       },

--- a/packages/lesswrong/server/callbacks/userCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/userCallbacks.ts
@@ -244,7 +244,11 @@ getCollectionHooks("Users").editAsync.add(async function subscribeToForumDigest 
   });
 });
 
-getCollectionHooks("Users").newAsync.add(async function subscribeToDripCampaign(user: DbUser) {
+/**
+ * This callback adds all new users to an audience in Mailchimp which will be used for a forthcoming
+ * (as of 2021-08-11) drip campaign.
+ */
+getCollectionHooks("Users").newAsync.add(async function subscribeToEAForumAudience(user: DbUser) {
   if (isAnyTest || forumTypeSetting.get() !== 'EAForum') {
     return;
   }

--- a/packages/lesswrong/server/callbacks/userCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/userCallbacks.ts
@@ -215,6 +215,10 @@ getCollectionHooks("Users").editAsync.add(async function subscribeToForumDigest 
   if (!mailchimpAPIKey || !mailchimpForumDigestListId) {
     return;
   }
+  if (!newUser.email) {
+    captureException(new Error(`Forum digest subscription failed: no email for user ${newUser.displayName}`))
+    return;
+  }
   const { lat: latitude, lng: longitude, known } = userGetLocation(newUser);
   const status = newUser.subscribedToDigest ? 'subscribed' : 'unsubscribed'; 
   
@@ -247,6 +251,10 @@ getCollectionHooks("Users").newAsync.add(async function subscribeToDripCampaign(
   const mailchimpAPIKey = mailchimpAPIKeySetting.get();
   const mailchimpEAForumListId = mailchimpEAForumListIdSetting.get();
   if (!mailchimpAPIKey || !mailchimpEAForumListId) {
+    return;
+  }
+  if (!user.email) {
+    captureException(new Error(`Subscription to EA Forum audience failed: no email for user ${user.displayName}`))
     return;
   }
   const { lat: latitude, lng: longitude, known } = userGetLocation(user);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4665,6 +4665,11 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+charenc@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+  integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
+
 check-error@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz"
@@ -5233,6 +5238,11 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+crypt@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
+  integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
 crypto-js@^3.1.9-1:
   version "3.3.0"
@@ -7846,7 +7856,7 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
-is-buffer@^1.1.5:
+is-buffer@^1.1.5, is-buffer@~1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -9492,6 +9502,15 @@ md5-file@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/md5-file/-/md5-file-5.0.0.tgz"
   integrity sha512-xbEFXCYVWrSx/gEKS1VPlg84h/4L20znVIulKw6kMfmBUAZNAnF00eczz9ICMl+/hjQGo5KSXRxbL/47X3rmMw==
+
+md5@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"
+  integrity sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==
+  dependencies:
+    charenc "0.0.2"
+    crypt "0.0.2"
+    is-buffer "~1.1.6"
 
 mdurl@^1.0.1, mdurl@~1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This PR adds code to automatically subscribe users to the forum digest on signup (or whenever they toggle the `subscribedToDigest` field, which is also accessible in account settings). Unsubscribe is also supported. It also adds all new users to a new Mailchimp audience for a forthcoming drip campaign.