### PR TITLE
Post default sticky priority migration

### DIFF
--- a/packages/lesswrong/server/migrations/2021-08-13-postDefaultStickyPriority.ts
+++ b/packages/lesswrong/server/migrations/2021-08-13-postDefaultStickyPriority.ts
@@ -1,0 +1,14 @@
+import { registerMigration, fillDefaultValues } from './migrationUtils';
+import { Posts } from '../../lib/collections/posts';
+
+registerMigration({
+  name: "postDefaultStickyPriority",
+  dateWritten: "2021-08-13",
+  idempotent: true,
+  action: async () => {
+    await fillDefaultValues({
+      collection: Posts,
+      fieldName: "stickyPriority"
+    });
+  }
+});

--- a/packages/lesswrong/server/migrations/index.ts
+++ b/packages/lesswrong/server/migrations/index.ts
@@ -76,3 +76,4 @@ import './2021-04-28-populateCommentDescendentCounts';
 import './2021-05-09-selfVoteOnTagRevisions';
 import './2021-06-05-fillWikiEditCount'
 import './2021-07-22-fixDuplicateEmails'
+import './2021-08-13-postDefaultStickyPriority'


### PR DESCRIPTION
Posts without a set sticky priority get sorted below all other posts on the front page. This affects posts from before ~April 30th of this year. Aaron ran into this while trying to publish an old draft from a forum user, which he couldn't get  to show up on the front page.

This PR resolves this by filling in the default priority for all posts.