### PR TITLE
add a forum digest subscription reminder to the Recent Discussion feed

### DIFF
--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionSubscribeReminder.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionSubscribeReminder.tsx
@@ -45,7 +45,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     alignItems: "flex-start",
     fontSize: 18,
     lineHeight: 1.75,
-    // marginBottom: 18,
   },
   mailIcon: {
     marginTop: 4,
@@ -62,7 +61,6 @@ const styles = (theme: ThemeType): JssStyles => ({
   subscribeButton: {
     margin: "18px auto 0",
     display: "block",
-    // background: "#d2e8d2",
     background: theme.palette.primary.main,
     color: "white"
   },
@@ -99,7 +97,7 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
   </div>: null
 
   useEffect(() => {
-    if (adminBranch == -1 && currentUser?.isAdmin) {
+    if (adminBranch === -1 && currentUser?.isAdmin) {
       setAdminBranch(randInt(4));
     }
   }, [adminBranch, currentUser?.isAdmin]);
@@ -115,7 +113,7 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
   }
 
   // Placeholder to prevent SSR mismatch, changed on load.
-  if (adminBranch == -1 && currentUser?.isAdmin)
+  if (adminBranch === -1 && currentUser?.isAdmin)
     return <div/>
 
   const maybeLaterButton = <Button
@@ -154,6 +152,7 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
     // since they chose to subscribe to an email, make sure this is false
     userSubscriptionData.unsubscribeFromAll = false;
 
+    // EA Forum does not care about email verification
     if (forumTypeSetting.get() !== 'EAForum' && !userEmailAddressIsVerified(currentUser)) {
       userSubscriptionData.whenConfirmationEmailSent = new Date();
     }
@@ -200,10 +199,6 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
         <WrappedLoginForm startingState="signup" />
       </div>
       {adminUiMessage}
-      {/*<div className={classes.buttons}>
-        {maybeLaterButton}
-        {dontAskAgainButton}
-      </div>*/}
     </AnalyticsWrapper>
   } else if (!userHasEmailAddress(currentUser) || adminBranch===1) {
     const emailType = forumTypeSetting.get() === 'EAForum' ? 'our weekly digest email' : 'curated posts';

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionSubscribeReminder.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionSubscribeReminder.tsx
@@ -20,7 +20,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginBottom: theme.spacing.unit*4,
     position: "relative",
     backgroundColor: "rgba(253,253,253)",
-
+    
     padding: 16,
     ...theme.typography.body2,
     boxShadow: theme.boxShadow,
@@ -32,7 +32,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   adminNotice: {
     fontStyle: "italic",
     textAlign: "left",
-    marginTop: 8,
+    marginTop: 22,
     fontSize: 12,
     lineHeight: 1.3,
   },
@@ -45,6 +45,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     alignItems: "flex-start",
     fontSize: 18,
     lineHeight: 1.75,
+  },
+  messageDescription: {
+    fontSize: 12,
+    marginTop: 8
   },
   mailIcon: {
     marginTop: 4,
@@ -62,7 +66,8 @@ const styles = (theme: ThemeType): JssStyles => ({
     margin: "18px auto 0",
     display: "block",
     background: theme.palette.primary.main,
-    color: "white"
+    color: "white",
+    fontSize: 15
   },
   buttons: {
     marginTop: 16,
@@ -86,8 +91,9 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
   const [loading, setLoading] = useState(false);
   const { flash } = useMessages();
   const {WrappedLoginForm, SignupSubscribeToCurated, Loading, AnalyticsInViewTracker } = Components;
+  const subscriptionDescription = '(2-3 posts per week, selected by the LessWrong moderation team.)';
   const { captureEvent } = useTracking({eventProps: {pageElementContext: "subscribeReminder"}});
-
+  
   // Show admins a random version of the widget. Makes sure we notice if it's intrusive/bad.
   const [adminBranch, setAdminBranch] = useState(-1);
   const adminUiMessage = currentUser?.isAdmin ? <div className={classes.adminNotice}>
@@ -95,26 +101,27 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
     subscribe-reminder even if they're already subscribed, to make sure it still works and isn't
     annoying.
   </div>: null
-
+  
   useEffect(() => {
     if (adminBranch === -1 && currentUser?.isAdmin) {
       setAdminBranch(randInt(4));
     }
   }, [adminBranch, currentUser?.isAdmin]);
 
-  // adjust functionality based on forum type
-  let forumType = 'LessWrong';
-  let subscriptionDescription = '(2-3 posts per week, selected by the LessWrong moderation team.)';
-  let currentUserSubscribed = currentUser?.emailSubscribedToCurated;
-  if (forumTypeSetting.get() === 'EAForum') {
-    forumType = 'the EA Forum';
-    subscriptionDescription = '';
-    currentUserSubscribed = currentUser?.subscribedToDigest;
+  // disable on AlignmentForum
+  if (forumTypeSetting.get() === 'AlignmentForum') {
+    return null;
   }
 
   // Placeholder to prevent SSR mismatch, changed on load.
   if (adminBranch === -1 && currentUser?.isAdmin)
     return <div/>
+
+  // adjust functionality based on forum type
+  let currentUserSubscribed = currentUser?.emailSubscribedToCurated;
+  if (forumTypeSetting.get() === 'EAForum') {
+    currentUserSubscribed = currentUser?.subscribedToDigest;
+  }
 
   const maybeLaterButton = <Button
     className={classes.maybeLaterButton}
@@ -125,7 +132,7 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
   >
     Maybe Later
   </Button>
-
+  
   const dontAskAgainButton = <span>
     {currentUser && <Button
       className={classes.dontAskAgainButton}
@@ -138,11 +145,11 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
       Don't Ask Again
     </Button>}
   </span>
-
+  
   if (hide || currentUser?.hideSubscribePoke) {
     return null;
   }
-
+  
   const updateAndMaybeVerifyEmail = async () => {
     setLoading(true);
 
@@ -166,7 +173,7 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
 
     setLoading(false);
   }
-
+  
   const AnalyticsWrapper = ({children, branch}: {children: React.ReactNode, branch: string}) => {
     return <AnalyticsContext pageElementContext="subscribeReminder" branch={branch}>
       <AnalyticsInViewTracker eventProps={{inViewType: "subscribeReminder"}}>
@@ -176,25 +183,47 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
       </AnalyticsInViewTracker>
     </AnalyticsContext>
   }
-
+  
+  // the EA Forum uses this prompt in most cases
+  const eaForumSubscribePrompt = (
+    <>
+      <div className={classes.message}>
+        <MailOutline className={classes.mailIcon} />
+        Sign up for the Forum's email digest
+      </div>
+      <div className={classes.messageDescription}>
+        Want a weekly email containing the best posts from the past week?
+        Our moderator Aaron sends out a weekly digest of recent posts that
+        have a lot of karma/discussion or seemed really good to him, as well
+        as question posts that could use more answers.
+      </div>
+    </>
+  );
+  
   if (loading) {
     return <div className={classes.root}>
       <Loading/>
     </div>
   } else if (subscriptionConfirmed) {
+    // Show the confirmation after the user subscribes
+    const confirmText = forumTypeSetting.get() === 'EAForum' ?
+      "You're subscribed to the EA Forum Digest!" :
+      "You are subscribed to the best posts of LessWrong!"
     return <AnalyticsWrapper branch="already-subscribed">
       <div className={classes.message}>
         <CheckRounded className={classes.checkIcon} />
-        You are subscribed to the best posts of {forumType}!
+        {confirmText}
       </div>
     </AnalyticsWrapper>
   } else if (!currentUser || adminBranch===0) {
     // Not logged in. Show a create-account form and a brief pitch.
-    return <AnalyticsWrapper branch="logged-out">
+    const subscribeTextNode = forumTypeSetting.get() === 'EAForum' ? eaForumSubscribePrompt : (
       <div className={classes.message}>
-        <MailOutline className={classes.mailIcon} />
         To get the best posts emailed to you, create an account! {subscriptionDescription}
       </div>
+    );
+    return <AnalyticsWrapper branch="logged-out">
+      {subscribeTextNode}
       <div className={classes.loginForm}>
         <WrappedLoginForm startingState="signup" />
       </div>
@@ -209,10 +238,10 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
       <div className={classes.message}>
         Your account does not have an email address associated. Add an email address to subscribe to {emailType} and enable notifications.
       </div>
-
+      
       <Input placeholder="Email address" inputRef={emailAddressInput} className={classes.emailInput} />
       <SignupSubscribeToCurated defaultValue={true} onChange={(checked: boolean) => setSubscribeChecked(true)}/>
-
+      
       <div className={classes.buttons}>
         <Button className={classes.subscribeButton} onClick={async (ev) => {
           const emailAddress = emailAddressInput.current;
@@ -259,11 +288,14 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
     // on re-subscribing. A big Subscribe button, which clears the
     // unsubscribe-from-all option, activates curation emails (if not already
     // activated), and sends a confirmation email (if needed).
-    return <AnalyticsWrapper branch="previously-unsubscribed">
+    const subscribeTextNode = forumTypeSetting.get() === 'EAForum' ? eaForumSubscribePrompt : (
       <div className={classes.message}>
-        <MailOutline className={classes.mailIcon} />
-        You previously unsubscribed from all emails from {forumType}. Re-subscribe to get the best posts emailed to you! {subscriptionDescription}
+        You previously unsubscribed from all emails from LessWrong.
+        Re-subscribe to get the best posts emailed to you! {subscriptionDescription}
       </div>
+    );
+    return <AnalyticsWrapper branch="previously-unsubscribed">
+      {subscribeTextNode}
       <Button className={classes.subscribeButton} onClick={async (ev) => {
         await updateAndMaybeVerifyEmail();
         captureEvent("subscribeReminderButtonClicked", {buttonType: "subscribeButton"});
@@ -279,14 +311,13 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
     // account, but is not subscribed to curated posts. A Subscribe button which
     // sets the subscribe-to-curated option, and (if their email address isn't
     // verified) resends the verification email.
-    const subscribeText = forumTypeSetting.get() === 'EAForum' ?
-      'Subscribe to our weekly EA Forum Digest email!' :
-      `Subscribe to get the best of LessWrong emailed to you. ${subscriptionDescription}`;
-    return <AnalyticsWrapper branch="logged-in-not-subscribed">
+    const subscribeTextNode = forumTypeSetting.get() === 'EAForum' ? eaForumSubscribePrompt : (
       <div className={classes.message}>
-        <MailOutline className={classes.mailIcon} />
-        {subscribeText}
+        Subscribe to get the best of LessWrong emailed to you. {subscriptionDescription}
       </div>
+    );
+    return <AnalyticsWrapper branch="logged-in-not-subscribed">
+      {subscribeTextNode}
       <Button className={classes.subscribeButton} onClick={async (ev) => {
         await updateAndMaybeVerifyEmail();
         captureEvent("subscribeReminderButtonClicked", {buttonType: "subscribeButton"});

--- a/packages/lesswrong/components/users/SignupSubscribeToCurated.tsx
+++ b/packages/lesswrong/components/users/SignupSubscribeToCurated.tsx
@@ -3,6 +3,7 @@ import { registerComponent } from '../../lib/vulcan-lib';
 import Checkbox from '@material-ui/core/Checkbox';
 import Info from '@material-ui/icons/Info';
 import Tooltip from '@material-ui/core/Tooltip';
+import { forumTypeSetting } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -34,6 +35,10 @@ const SignupSubscribeToCurated = ({ defaultValue, onChange, classes }: {
   classes: ClassesType,
 }) => {
   const [checked, setChecked] = useState(defaultValue);
+
+  const emailType = forumTypeSetting.get() === 'EAForum' ?
+    'the EA Forum weekly digest email' : 'Curated posts';
+
   return <div className={classes.root}>
     <Checkbox
       checked={checked}
@@ -43,10 +48,12 @@ const SignupSubscribeToCurated = ({ defaultValue, onChange, classes }: {
         onChange(newChecked)
       }}
     />
-    Subscribe to Curated posts
-    <Tooltip title="Emails 2-3 times per week with the best posts, chosen by the LessWrong moderation team.">
-      <Info className={classes.infoIcon}/>
-    </Tooltip>
+    Subscribe to {emailType}
+    {forumTypeSetting.get() !== 'EAForum' && (
+      <Tooltip title="Emails 2-3 times per week with the best posts, chosen by the LessWrong moderation team.">
+        <Info className={classes.infoIcon}/>
+      </Tooltip>
+    )}
   </div>
 }
 

--- a/packages/lesswrong/components/users/SignupSubscribeToCurated.tsx
+++ b/packages/lesswrong/components/users/SignupSubscribeToCurated.tsx
@@ -37,7 +37,7 @@ const SignupSubscribeToCurated = ({ defaultValue, onChange, classes }: {
   const [checked, setChecked] = useState(defaultValue);
 
   // this component is not used in the EA Forum signup flow,
-  // but it does appear on the EA Forum via RecentDiscussionSubscribeReminder.jsx
+  // but it does appear on the EA Forum via RecentDiscussionSubscribeReminder.tsx
   const emailType = forumTypeSetting.get() === 'EAForum' ?
     'the EA Forum weekly digest email' : 'Curated posts';
 

--- a/packages/lesswrong/components/users/SignupSubscribeToCurated.tsx
+++ b/packages/lesswrong/components/users/SignupSubscribeToCurated.tsx
@@ -36,6 +36,8 @@ const SignupSubscribeToCurated = ({ defaultValue, onChange, classes }: {
 }) => {
   const [checked, setChecked] = useState(defaultValue);
 
+  // this component is not used in the EA Forum signup flow,
+  // but it does appear on the EA Forum via RecentDiscussionSubscribeReminder.jsx
   const emailType = forumTypeSetting.get() === 'EAForum' ?
     'the EA Forum weekly digest email' : 'Curated posts';
 


### PR DESCRIPTION
<img width="500" alt="Screen Shot 2021-09-09 at 10 18 32 PM" src="https://user-images.githubusercontent.com/9057804/132868598-995fe4e1-7344-4e3d-8a67-52e51df6a1b3.png">

This PR adds a small CTA capsule in the Recent Discussion feed. It's main purpose is to prompt signing up for the EA Forum weekly digest email (or the LW curated posts email depending on the forum type) if the user has not already done so. Logged out users will be prompted to create an account or login.

I generally feel like we can get rid of the "Maybe Later" button and compress the component to make it less obtrusive, but for the initial pass I wanted to focus on getting it working and not mess with the LW experience. (I did remove the "Maybe Later" button from the logged out view because it seemed pretty useless for that version.)

<img width="500" alt="Screen Shot 2021-09-09 at 10 38 43 PM" src="https://user-images.githubusercontent.com/9057804/132868660-2fa3fc58-dac2-4453-9c00-caac0d48a500.png">


### Screenshot from my first version
<img width="500" alt="Screen Shot 2021-09-07 at 11 11 01 AM" src="https://user-images.githubusercontent.com/9057804/132526649-3bff4312-77e6-4ba4-a440-5795cdcc0305.png">