### PR TITLE
Fix issues around post-ban spamming

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -311,7 +311,7 @@ class Layout extends PureComponent<LayoutProps,LayoutState> {
                   <ErrorBoundary>
                     <FlashMessages />
                   </ErrorBoundary>
-                  <ErrorBoundary>                  
+                  <ErrorBoundary>
                     {userIsBanned
                       ? <BannedNotice />
                       : (currentUser?.usernameUnset

--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -312,13 +312,7 @@ class Layout extends PureComponent<LayoutProps,LayoutState> {
                     <FlashMessages />
                   </ErrorBoundary>
                   <ErrorBoundary>
-                    {userIsBanned
-                      ? <BannedNotice />
-                      : (currentUser?.usernameUnset
-                        ? <NewUserCompleteProfile />
-                        : children
-                      )
-                    }
+                    {children}
                   </ErrorBoundary>
                   <Footer />
                 </div>

--- a/packages/lesswrong/components/users/BannedNotice.tsx
+++ b/packages/lesswrong/components/users/BannedNotice.tsx
@@ -1,18 +1,37 @@
+import { Typography } from '@material-ui/core';
 import React from 'react';
 import { siteNameWithArticleSetting } from '../../lib/instanceSettings';
+import { Link } from '../../lib/reactRouterWrapper';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 
 const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+    backgroundColor: 'white',
+    width: '100%',
+    padding: 32,
+    '& a': {
+      color: theme.palette.primary.main,
+    },
+  },
 });
 
 const BannedNotice = ({classes}: {
   classes: ClassesType
 }) => {
-  const {SingleColumnSection} = Components;
+  const {SingleColumnSection, } = Components;
   
   return <SingleColumnSection>
-    <p>Sorry, but we have banned your account. You can still read {siteNameWithArticleSetting.get()}
-    in logged-out mode, but you will not be able to post or comment.</p>
+    <div className={classes.root}>
+      <Typography variant='body2' gutterBottom>
+        Sorry, but we have banned your account. You can still read{' '}
+        {siteNameWithArticleSetting.get()} in logged-out mode, but you will not be able to post or
+        comment.
+      </Typography>
+
+      <Typography variant='body2'>
+        If you believe this is a mistake, please <Link to='/contact-us'>contact us.</Link>
+      </Typography>
+    </div>
   </SingleColumnSection>
 }
 

--- a/packages/lesswrong/components/vulcan-forms/Form.tsx
+++ b/packages/lesswrong/components/vulcan-forms/Form.tsx
@@ -301,8 +301,6 @@ class SmartForm extends Component<any,any> {
     // sort by order
     groups = _.sortBy(groups, 'order');
 
-    // console.log(groups);
-
     return groups;
   };
 

--- a/packages/lesswrong/lib/vulcan-lib/errors.ts
+++ b/packages/lesswrong/lib/vulcan-lib/errors.ts
@@ -77,28 +77,34 @@ Scenario 4: single GraphQL error with no data property
 
 */
 export const getErrors = error => {
-
-  // 1. wrap in array
-  let errors = [error];
   // if this is one or more GraphQL errors, extract and convert them
   if (error.graphQLErrors && error.graphQLErrors.length > 0) {
     // get graphQL error (see https://github.com/thebigredgeek/apollo-errors/issues/12)
-    const graphQLError = error.graphQLErrors[0];
-    const data = (graphQLError && graphQLError.extensions && graphQLError.extensions.exception && graphQLError.extensions.exception.data) ||
-                 graphQLError.data
-                 
+    const graphQLError = error.graphQLErrors[0]
+    const data = (graphQLError?.extensions?.exception?.data) || graphQLError.data
+
+    let baseErrorMessages = parseErrorMessage(graphQLError.message)
     if (data && !isEmpty(data)) {
       if (data.errors) {
-        // 2. there are multiple errors on the data.errors object
-        errors = data.errors;
-      } else {
-        // 3. there is only one error
-        errors = [data];
+        // 2. There are multiple errors on the data.errors object
+        // Check for helpful message
+        if (data.errors.some(e => e.message)) {
+          return data.errors
+        }
+        // Otherwise we need at least one helpful message
+        return baseErrorMessages.concat(data.errors)
       }
-    } else {
-      // 4. there is no data object, try to parse raw error message
-      errors = parseErrorMessage(graphQLError.message);
+      // 3. There is only one error
+      // Check for helpful message
+      if (data.message) {
+        return [data]
+      }
+      // Again we need a helpful message
+      return baseErrorMessages.concat([data])
     }
+    // 4. There is no data object, just use the raw error messages
+    return baseErrorMessages
   }
-  return errors;
+  // 1. Wrap in array
+  return [error]
 }

--- a/packages/lesswrong/lib/vulcan-users/permissions.ts
+++ b/packages/lesswrong/lib/vulcan-users/permissions.ts
@@ -1,4 +1,5 @@
 import intersection from 'lodash/intersection';
+import moment from 'moment';
 import * as _ from 'underscore';
 import { getSchema } from'../utils/getSchema';
 
@@ -33,19 +34,21 @@ export const createGroup = (groupName: string): Group => {
 export const userGetGroups = (user: UsersProfile|DbUser|null): Array<string> => {
   if (!user) { // guests user
     return ['guests'];
-  } else {
-    let userGroups: Array<string> = ['members'];
-
-    if (user.groups) { // custom groups
-      userGroups = userGroups.concat(user.groups);
-    }
-
-    if (userIsAdmin(user)) { // admin
-      userGroups.push('admins');
-    }
-    
-    return userGroups;
   }
+  if (user.banned > moment().toDate()) { // banned users have no membership permissions
+    return ['guests'];
+  }
+  let userGroups: Array<string> = ['members'];
+
+  if (user.groups) { // custom groups
+    userGroups = userGroups.concat(user.groups);
+  }
+
+  if (userIsAdmin(user)) { // admin
+    userGroups.push('admins');
+  }
+  
+  return userGroups;
 };
 
 // Get a list of all the actions a user can perform

--- a/packages/lesswrong/server/akismet.ts
+++ b/packages/lesswrong/server/akismet.ts
@@ -68,7 +68,7 @@ async function checkForAkismetSpam({document, type = "post"}) {
     const akismetReport = await constructAkismetReport({document, type})
     const spam = await getAkismetClient().checkSpam(akismetReport)
     // eslint-disable-next-line no-console
-    console.log("Checked document for spam: ", akismetReport, "result: ", spam)
+    console.log("Checked document for spam: ", akismetReport, "result is spam: ", spam)
     return spam
   } catch (e) {
     // eslint-disable-next-line no-console

--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -72,18 +72,17 @@ export function startWebserver() {
   const expressSessionSecret = expressSessionSecretSetting.get()
 
   app.use(universalCookiesMiddleware());
+  // Required for passport-auth0, and for login redirects
   if (expressSessionSecret) {
     const store = MongoStore.create({
       client: getMongoClient()
     })
-    // Required by passport-auth0
     app.use(expressSession({
       secret: expressSessionSecret,
       resave: false,
       saveUninitialized: false,
       store,
       cookie: {
-        // We match LW - ten year login tokens
         // NB: Although the Set-Cookie HTTP header takes seconds,
         // express-session wants milliseconds for some reason
         maxAge: 1000 * 60 * 60 * 24 * 365 * 10

--- a/packages/lesswrong/server/authenticationMiddlewares.ts
+++ b/packages/lesswrong/server/authenticationMiddlewares.ts
@@ -164,7 +164,6 @@ passport.deserializeUser(deserializeUserPassport)
 
 export const addAuthMiddlewares = (addConnectHandler) => {
   addConnectHandler(passport.initialize())
-  addConnectHandler(passport.session())
   passport.use(cookieAuthStrategy)
   
   addConnectHandler('/', (req, res, next) => {

--- a/packages/lesswrong/server/callbacks.ts
+++ b/packages/lesswrong/server/callbacks.ts
@@ -232,6 +232,12 @@ async function deleteUserTagsAndRevisions(user: DbUser, deletingUser: DbUser) {
   }
 }
 
+/**
+ * Add user IP address to IP ban list for a day and remove their login tokens
+ *
+ * NB: We haven't tested the IP ban list in like 3 years and it should not be
+ * assumed to work.
+ */
 export async function userIPBanAndResetLoginTokens(user: DbUser) {
   // IP ban
   const query = `

--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -235,8 +235,8 @@ getCollectionHooks("Comments").newValidate.add(function NewCommentsEmptyCheck (c
   return comment;
 });
 
-export async function commentsDeleteSendPMAsync (comment: DbComment, currentUser: DbUser) {
-  if (currentUser._id !== comment.userId && comment.deleted && comment.contents && comment.contents.html) {
+export async function commentsDeleteSendPMAsync (comment: DbComment, currentUser: DbUser | undefined) {
+  if (currentUser?._id !== comment.userId && comment.deleted && comment.contents?.html) {
     const onWhat = comment.tagId
       ? (await Tags.findOne(comment.tagId))?.name
       : (comment.postId
@@ -446,4 +446,3 @@ getCollectionHooks("Comments").createAfter.add(async (document: DbComment) => {
   await newDocumentMaybeTriggerReview(document);
   return document;
 })
-


### PR DESCRIPTION
*Issue 1: If you get banned you can still login*

The proximate cause of the error is that express-session keeps you logged in. We remove your loginToken when you get banned, which would log you out, but now express session also has a cookie-based method to keep you logged in. Turns out we don't need to ask passport to use express-session to track logins, so I've removed it. It was silly to have the duplication. Upon doing so, I've removed the code that showed people the banned notice if they're logged in while being banned.

To restate / clarify:

Previously the state would be:
* DB:
  * user.services.resume.loginTokens: 'asdf'
  * sessions.something: 'zxvc'
* Client cookies: 
  * loginToken: 'hjkl'
  * connect.sid: 'nmop'

Now we only have the loginToken ones.

*Issue 2: Even if somehow logged-in, I claim that banned users should not be able to post*

Fundamentally, I claim this issue should be guarded against at the permissions level.

Only members can post. Why are banned users members anyway? We can change that!

*Issue 3: When testing that banned users who were logged in couldn't comment, I got a very unhelpful error message*

Kinda hackily fixed. We should dig into our graphql error handling and fix it all, but right now I'm just assuming that the initial structure was important and only modifying it a little.

*Issue 4: The banned notice page was a little sad*

Now it is slightly less sad.