### PR TITLE
Don't promote events to frontpage by default

### DIFF
--- a/packages/lesswrong/components/posts/SubmitToFrontpageCheckbox.tsx
+++ b/packages/lesswrong/components/posts/SubmitToFrontpageCheckbox.tsx
@@ -5,13 +5,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 import { registerComponent } from '../../lib/vulcan-lib';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 
-const forumDefaultCheckboxLabels = {
-  LessWrong: 'Moderators may promote to Frontpage',
-  AlignmentForum: 'Moderators may promote to Frontpage',
-  EAForum: 'Moderators may promote to Frontpage or Community'
-}
-
-const defaultCheckboxLabel = forumDefaultCheckboxLabels[forumTypeSetting.get()]
+const defaultCheckboxLabel = 'Moderators may promote to Frontpage'
 
 const defaultTooltipLWAF = ({classes}: {classes: ClassesType}) => <div className={classes.tooltip}>
   <p>LW moderators will consider this post for frontpage</p>

--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -17,7 +17,15 @@ import { captureException } from '@sentry/core';
 import { formGroups } from './formGroups';
 
 const isEAForum = forumTypeSetting.get() === 'EAForum'
-const frontpageDefault = isEAForum ? () => new Date() : undefined
+function forumFrontpageDate (document: Partial<DbPost>) {
+  if (document.isEvent || !document.submitToFrontpage) {
+    return undefined
+  }
+  return new Date()
+}
+const frontpageDefault = isEAForum ?
+  forumFrontpageDate :
+  undefined
 
 const userHasModerationGuidelines = (currentUser: DbUser|null): boolean => {
   return !!(currentUser && ((currentUser.moderationGuidelines && currentUser.moderationGuidelines.html) || currentUser.moderationStyle))


### PR DESCRIPTION
Also avoid promoting posts where the author wants it to stay in personal

Unlike LW, we default posts to the frontpage by default and pull them out if they don't meet the bar. This meant we were:

1. Promoting events to the frontpage by default, cluttering the frontpage until a moderator removed it
2. Promoting posts that the author said they wanted to stay in personal (see screenshot)

Both of those are now fixed.

Also fix the wording, as we haven't had a Community section in a good while.

![image](https://user-images.githubusercontent.com/10352319/133420347-5f377160-92e9-4192-85d9-b50745d6a531.png)
