### PR TITLE
dont show draft sequences to people who arent the author

### DIFF
--- a/packages/lesswrong/components/sequences/SequencesPage.tsx
+++ b/packages/lesswrong/components/sequences/SequencesPage.tsx
@@ -125,6 +125,9 @@ const SequencesPage = ({ documentId, classes }: {
   const canCreateChapter = userCanDo(currentUser, 'chapters.new.all')
   const { html = "" } = document.contents || {}
 
+  if (!canEdit && document.draft)
+    throw new Error('This sequence is a draft and is not publicly visible')
+    
   return <div className={classes.root}>
     <HeadTags canonicalUrl={sequenceGetPageUrl(document, true)} title={document.title}/>
     <div className={classes.banner}>


### PR DESCRIPTION
Fixes [this issue](https://app.asana.com/0/628521446211730/1200805988361616/f).

Previously, anyone can view a draft sequence. Now, only people who have access to edit the sequence can view it.