### PR TITLE
Ask users from facebook without an email for their email

### DIFF
--- a/packages/lesswrong/components/users/NewUserCompleteProfile.tsx
+++ b/packages/lesswrong/components/users/NewUserCompleteProfile.tsx
@@ -1,6 +1,6 @@
 import { gql, useMutation } from "@apollo/client";
 import { Button, Checkbox, FormControlLabel, TextField, Typography } from "@material-ui/core";
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import { forumTypeSetting, siteNameWithArticleSetting } from "../../lib/instanceSettings";
 import { Components, registerComponent } from "../../lib/vulcan-lib";
 import { useMessages } from "../common/withMessages";
@@ -41,7 +41,7 @@ function prefillUsername(maybeUsername: string | undefined | null): string {
 const NewUserCompleteProfile: React.FC<NewUserCompleteProfileProps> = ({ classes }) => {
   const currentUser = useCurrentUser()
   const [username, setUsername] = useState(prefillUsername(currentUser?.displayName))
-  const [newEmail, setNewEmail] = useState('')
+  const emailInput = useRef<HTMLInputElement>(null)
   const [subscribeToDigest, setSubscribeToDigest] = useState(false)
   const [validationError, setValidationError] = useState('')
   const [updateUser] = useMutation(gql`
@@ -83,8 +83,8 @@ const NewUserCompleteProfile: React.FC<NewUserCompleteProfileProps> = ({ classes
         subscribeToDigest,
         // We do this fancy spread so we avoid setting the email to an empty
         // string in the likely event that someone already had an email and
-        // wasn't show the set email field
-        ...(newEmail && {email: newEmail})
+        // wasn't shown the set email field
+        ...(!currentUser?.email && {email: emailInput.current?.value})
       }})
     } catch (err) {
       if (/duplicate key error/.test(err.toString?.())) {
@@ -97,7 +97,7 @@ const NewUserCompleteProfile: React.FC<NewUserCompleteProfileProps> = ({ classes
   }
   
   return <SingleColumnSection>
-      <div className={classes.root}>
+    <div className={classes.root}>
       <Typography variant='display3' gutterBottom className={classes.title}>
         Thanks for registering for {siteNameWithArticleSetting.get()}
       </Typography>
@@ -136,7 +136,8 @@ const NewUserCompleteProfile: React.FC<NewUserCompleteProfileProps> = ({ classes
         </Typography>
         <TextField
           label='Email'
-          onChange={(event) => setNewEmail(event.target.value)}
+          inputRef={emailInput}
+          // onChange={(event) => setNewEmail(event.target.value)}
         />
       </div>}
       

--- a/packages/lesswrong/server/resolvers/userResolvers.ts
+++ b/packages/lesswrong/server/resolvers/userResolvers.ts
@@ -37,12 +37,13 @@ addGraphQLSchema(`
 
 type NewUserUpdates = {
   username: string
+  email?: string
   subscribeToDigest: boolean
 }
 
 addGraphQLResolvers({
   Mutation: {
-    async NewUserCompleteProfile(root: void, { username, subscribeToDigest }: NewUserUpdates, context: ResolverContext) {
+    async NewUserCompleteProfile(root: void, { username, email, subscribeToDigest }: NewUserUpdates, context: ResolverContext) {
       const { currentUser } = context
       if (!currentUser) {
         throw new Error('Cannot change username without being logged in')
@@ -57,6 +58,14 @@ addGraphQLResolvers({
       if (existingUser && existingUser._id !== currentUser._id) {
         throw new Error('Username already exists')
       }
+      // Check for someone setting an email when they already have one
+      if (email && currentUser.email) {
+        throw new Error('You already have an email address')
+      }
+      // Check for email uniqueness
+      if (email && await Users.findOne({email})) {
+        throw new Error('Email already taken')
+      }
       const updatedUser = (await updateMutator({
         collection: Users,
         documentId: currentUser._id,
@@ -65,6 +74,7 @@ addGraphQLResolvers({
           username,
           displayName: username,
           slug: await Utils.getUnusedSlugByCollectionName("Users", slugify(username)),
+          email,
           subscribedToDigest: subscribeToDigest
         },
         // We've already done necessary gating
@@ -77,5 +87,5 @@ addGraphQLResolvers({
 })
 
 addGraphQLMutation(
-  'NewUserCompleteProfile(username: String!, subscribeToDigest: Boolean!): NewUserCompletedProfile'
+  'NewUserCompleteProfile(username: String!, subscribeToDigest: Boolean!, email: String): NewUserCompletedProfile'
 )

--- a/packages/lesswrong/server/resolvers/userResolvers.ts
+++ b/packages/lesswrong/server/resolvers/userResolvers.ts
@@ -3,6 +3,7 @@ import Users from '../../lib/collections/users/collection';
 import { augmentFieldsDict, denormalizedField } from '../../lib/utils/schemaUtils'
 import { addGraphQLMutation, addGraphQLResolvers, addGraphQLSchema, slugify, updateMutator, Utils } from '../vulcan-lib';
 import pick from 'lodash/pick';
+import SimpleSchema from 'simpl-schema';
 
 augmentFieldsDict(Users, {
   htmlBio: {
@@ -65,6 +66,10 @@ addGraphQLResolvers({
       // Check for email uniqueness
       if (email && await Users.findOne({email})) {
         throw new Error('Email already taken')
+      }
+      // Check for valid email
+      if (email && !SimpleSchema.RegEx.Email.test(email)) {
+        throw new Error('Invalid email')
       }
       const updatedUser = (await updateMutator({
         collection: Users,

--- a/packages/lesswrong/server/resolvers/userResolvers.ts
+++ b/packages/lesswrong/server/resolvers/userResolvers.ts
@@ -64,7 +64,7 @@ addGraphQLResolvers({
         throw new Error('You already have an email address')
       }
       // Check for email uniqueness
-      if (email && await Users.findOne({email})) {
+      if (email && await Users.findOne({$or: [{email}, {['emails.address']: email}]})) {
         throw new Error('Email already taken')
       }
       // Check for valid email


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10352319/134921280-c204700d-584b-41a0-866c-a4998aacabfe.png)

The ways to sign up are:

* Auth0 email + password
* Auth0 google OAuth
* Auth0 facebook OAuth

Only Facebook allows for no email to be set, so I'm confident in that text.

I've checked that this doesn't change the flow if you do have an email.

I don't do any validation of the email address on the frontend, because this is only for .5 users every month, so I don't think it's worth it. I do check on the backend though. The error propagates sensibly if you submit a malformed email address.