### PR TITLE
add a script to clean up some user email data

### DIFF
--- a/packages/lesswrong/server.ts
+++ b/packages/lesswrong/server.ts
@@ -34,6 +34,7 @@ import './server/scripts/nullifyVotes';
 import './server/scripts/fixSSCDrafts';
 
 import './server/scripts/oneOffBanSpammers'
+import './server/scripts/ensureEmailInEmails';
 import './server/scripts/exportPostDetails';
 import './server/scripts/legacyKarma_aggregate2';
 import './server/scripts/removeObsoleteIndexes';

--- a/packages/lesswrong/server/scripts/ensureEmailInEmails.ts
+++ b/packages/lesswrong/server/scripts/ensureEmailInEmails.ts
@@ -1,0 +1,52 @@
+import { wrapVulcanAsyncScript } from './utils'
+import { Vulcan } from '../vulcan-lib';
+import Users from '../../lib/collections/users/collection'
+
+/*
+ * This script attempts to ensure that all users with an "email" value
+ * also have that email address listed in their "emails" array,
+ * by appending it to the array if it is not already there
+ * and it is not in another user's "emails" array.
+ */
+Vulcan.ensureEmailInEmails = wrapVulcanAsyncScript(
+  'ensureEmailInEmails',
+  async () => {
+    const allUsers = Users.find({}, {fields: {emails: 1}});
+    // build a set of all email addresses from the "emails", to be used in a later comparison
+    const allEmails = new Set();
+    for (const user of await allUsers.fetch()) {
+      if (user.emails && user.emails.length) {
+        user.emails.forEach(email => allEmails.add(email.address?.toLowerCase()));
+      }
+    }
+    
+    // {$nin: [null, ''] excludes users without the email field because mongo considers undefined as equal to null
+    const usersWithEmail = Users.find({
+      email: {$nin: [null, '']},
+    }, {fields: {email: 1, emails: 1}});
+    
+    for (const user of await usersWithEmail.fetch()) {
+      // goddamnit
+      if (user.email === 'foo@example.com') {
+        continue;
+      }
+      
+      // if the user's email is already in emails, skip them because their data is already correct
+      if (user.emails && user.emails.map(email => email.address?.toLowerCase()).includes(user.email.toLowerCase())) {
+        continue;
+      }
+
+      if (allEmails.has(user.email.toLowerCase())) {
+        // eslint-disable-next-line no-console
+        console.log("email found in another user's account:", user.email);
+      } else {
+        // add email to emails
+        const newEmail = {address: user.email, verified: true};
+        const newEmails = user.emails ? [...user.emails, newEmail] : [newEmail]
+        Users.update(user._id, {$set: {'emails': newEmails}});
+        // eslint-disable-next-line no-console
+        console.log('updating user account:', user.email, user.emails, newEmails);
+      }
+    }
+  }
+);

--- a/packages/lesswrong/server/scripts/ensureEmailInEmails.ts
+++ b/packages/lesswrong/server/scripts/ensureEmailInEmails.ts
@@ -43,7 +43,7 @@ Vulcan.ensureEmailInEmails = wrapVulcanAsyncScript(
         // add email to emails
         const newEmail = {address: user.email, verified: true};
         const newEmails = user.emails ? [...user.emails, newEmail] : [newEmail]
-        Users.update(user._id, {$set: {'emails': newEmails}});
+        void Users.update(user._id, {$set: {'emails': newEmails}});
         // eslint-disable-next-line no-console
         console.log('updating user account:', user.email, user.emails, newEmails);
       }


### PR DESCRIPTION
This script tries to ensure that users with an `email` also have that listed in their `emails` by appending it to the array if it's not already there and the `email` is not in a different user's `emails`.