### PR TITLE
Remove "beta" from Groups/Events page, and hide newly created in-person events in Recent Discussion

### DIFF
--- a/packages/lesswrong/components/localGroups/CommunityHome.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityHome.tsx
@@ -118,7 +118,7 @@ const CommunityHome = ({classes}: {
                   {currentUser?.mapLocation ? "Edit my location on the map" : "Add me to the map"}
                 </a>}
                 <a onClick={openEventNotificationsForm}>
-                  {currentUser?.nearbyEventsNotifications ? `Edit my event/groups notification settings` : `Sign up for event/group notifications`} [Beta]
+                  {currentUser?.nearbyEventsNotifications ? `Edit my event/groups notification settings` : `Sign up for event/group notifications`}
                 </a>
               </SectionFooter>
             </SingleColumnSection>

--- a/packages/lesswrong/server/resolvers/recentDiscussionFeed.ts
+++ b/packages/lesswrong/server/resolvers/recentDiscussionFeed.ts
@@ -32,7 +32,7 @@ defineFeedResolver<Date>({
           selector: {
             baseScore: {$gt:0},
             hideFrontpageComments: false,
-            $or: [{isEvent: false}, {commentCount: {$nin:[0,null]}}],
+            $or: [{isEvent: false}, {onlineEvent: true}, {commentCount: {$nin:[0,null]}}],
             hiddenRelatedQuestion: undefined,
             shortform: undefined,
             groupId: undefined,

--- a/packages/lesswrong/server/resolvers/recentDiscussionFeed.ts
+++ b/packages/lesswrong/server/resolvers/recentDiscussionFeed.ts
@@ -32,6 +32,7 @@ defineFeedResolver<Date>({
           selector: {
             baseScore: {$gt:0},
             hideFrontpageComments: false,
+            $or: [{isEvent: false}, {commentCount: {$nin:[0,null]}}],
             hiddenRelatedQuestion: undefined,
             shortform: undefined,
             groupId: undefined,


### PR DESCRIPTION
This PR removes the word "beta" from the Groups/Events page, and it excludes newly created in-person events from the Recent Discussion section. A **comment** on an event will make it appear in Recent Discussion. Online events still appear in Recent Discussion.