### PR TITLE
Default reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code reviews to a CEA developer at random
+* @centre-for-effective-altruism/cea-developers

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,1 +1,0 @@
-All PRs should be made to the `devel` branch, not `master`. 


### PR DESCRIPTION
This should make github assign a reviewer by default, so we don't have to remember.