### PR TITLE
Fill emails messed up by bug

### DIFF
--- a/packages/lesswrong/server.ts
+++ b/packages/lesswrong/server.ts
@@ -32,6 +32,7 @@ import './server/scripts/debuggingScripts';
 import './server/scripts/rerunAFvotes';
 import './server/scripts/nullifyVotes';
 import './server/scripts/fixSSCDrafts';
+import './server/scripts/fillUserEmail';
 
 import './server/scripts/oneOffBanSpammers'
 import './server/scripts/ensureEmailInEmails';

--- a/packages/lesswrong/server/scripts/fillUserEmail.ts
+++ b/packages/lesswrong/server/scripts/fillUserEmail.ts
@@ -1,0 +1,19 @@
+import { wrapVulcanAsyncScript } from "./utils";
+import { Vulcan } from '../vulcan-lib';
+import Users from "../../lib/vulcan-users";
+
+/**
+ * Fixes users affected by a bug on 2021-10-05 where the NewUserCompleteProfile process was setting their email to null. Fortunately their emails were spared.
+ */
+Vulcan.fillUserEmail = wrapVulcanAsyncScript('fillUserEmail', async () => {
+  const users = await (Users.find({
+    createdAt: {$gt: new Date('2021-10-04')},
+    email: null,
+  }).fetch())
+  const userSlugs = users.map(user => user.slug)
+  // eslint-disable-next-line no-console
+  console.log('userSlugs', userSlugs)
+  for (const user of users) {
+    await Users.update({_id: user._id}, {$set: {email: user.emails[0].address}})
+  }
+})


### PR DESCRIPTION
Fixes users affected by a bug on 2021-10-05 where the NewUserCompleteProfile process was setting their email to null. (See: https://github.com/centre-for-effective-altruism/EAForum/pull/211). Fortunately their emails field was spared, so we can use that. This should have been a manual db process, but mongo is awful.