### PR TITLE
show upcoming nearby events on the main forum page sidebar

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -260,6 +260,9 @@ export const menuTabs: Record<ForumTypeString,Array<MenuTab>> = {
       showOnMobileStandalone: true,
       showOnCompressed: true
     }, {
+      id: 'eventsList',
+      customComponentName: "EventsList",
+    }, {
       id: 'divider',
       divider: true,
       showOnCompressed: true,


### PR DESCRIPTION
LessWrong shows some upcoming nearby events in their home page sidebar, and here we are adding that section to the EA Forum sidebar as well. I also noticed that that section was not using the browser's location data (which the Groups/Events page does), so I updated the logic to match that in `CommunityHome.tsx`.

<img width="400" alt="Screen Shot 2021-10-18 at 3 45 06 PM" src="https://user-images.githubusercontent.com/9057804/137827296-93d80526-f176-475d-a44e-9343ce875a96.png">
