### PR TITLE
Featured resource fix

### DIFF
--- a/packages/lesswrong/components/ea-forum/FeaturedResourceBanner.tsx
+++ b/packages/lesswrong/components/ea-forum/FeaturedResourceBanner.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import Button from '@material-ui/core/Button';
 import Card from '@material-ui/core/Card';
@@ -59,12 +59,13 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   }
 }));
 
-const FeaturedResourceBanner = ({terms, classes} : {
+const FeaturedResourceBanner = ({ terms, classes }: {
   terms: FeaturedResourcesViewTerms,
   classes: ClassesType
 }) => {
   const HIDE_FEATURED_RESOURCE_COOKIE = 'hide_featured_resource';
   const [cookies, setCookie] = useCookies([HIDE_FEATURED_RESOURCE_COOKIE])
+  const [resource, setResource] = useState<FeaturedResourcesFragment | undefined>(undefined)
   const { results, loading } = useMulti({
     terms,
     collectionName: 'FeaturedResources',
@@ -73,33 +74,38 @@ const FeaturedResourceBanner = ({terms, classes} : {
   });
   const { Typography } = Components
 
-  if(loading || !results.length) {
-    return null;
-  }
+  useEffect(() => {
+    if (loading || !results.length) {
+      return;
+    }
 
-  // Already checked for length, sample will not return undefined
-  const resource = sample(results)!
+    setResource(sample(results));
+  }, [results, loading]);
 
-  if(cookies[HIDE_FEATURED_RESOURCE_COOKIE]) {
+  if (cookies[HIDE_FEATURED_RESOURCE_COOKIE]) {
     return null;
   }
 
   const hideBanner = () => setCookie(
-    HIDE_FEATURED_RESOURCE_COOKIE, 
+    HIDE_FEATURED_RESOURCE_COOKIE,
     "true", {
     expires: moment().add(30, 'days').toDate(),
   });
 
+  if (!resource) {
+    return null;
+  }
+
   return <Card className={classes.card}>
     <Tooltip title="Hide this for the next month">
       <Button className={classes.closeButton} onClick={hideBanner}>
-          <CloseIcon className={classes.closeIcon}/>
-      </Button>    
+        <CloseIcon className={classes.closeIcon} />
+      </Button>
     </Tooltip>
     <Typography variant="title" className={classes.title}>
       {resource.title}
     </Typography>
-    <Divider className={classes.divider}/>
+    <Divider className={classes.divider} />
     <Typography variant="body2" className={classes.body}>
       {resource.body}
     </Typography>
@@ -112,7 +118,7 @@ const FeaturedResourceBanner = ({terms, classes} : {
 }
 
 const FeaturedResourceBannerComponent = registerComponent(
-  'FeaturedResourceBanner', FeaturedResourceBanner, {styles}
+  'FeaturedResourceBanner', FeaturedResourceBanner, { styles }
 )
 
 declare global {

--- a/packages/lesswrong/components/ea-forum/FeaturedResourceBanner.tsx
+++ b/packages/lesswrong/components/ea-forum/FeaturedResourceBanner.tsx
@@ -9,7 +9,7 @@ import CloseIcon from '@material-ui/icons/Close';
 import { useMulti } from '../../lib/crud/withMulti';
 import { useCookies } from 'react-cookie';
 import moment from 'moment';
-import _ from 'underscore';
+import sample from 'lodash/sample';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   card: {
@@ -77,7 +77,8 @@ const FeaturedResourceBanner = ({terms, classes} : {
     return null;
   }
 
-  const resource = _.sample(results) as FeaturedResourcesFragment;
+  // Already checked for length, sample will not return undefined
+  const resource = sample(results)!
 
   if(cookies[HIDE_FEATURED_RESOURCE_COOKIE]) {
     return null;

--- a/packages/lesswrong/lib/collections/featuredResources/views.ts
+++ b/packages/lesswrong/lib/collections/featuredResources/views.ts
@@ -13,6 +13,6 @@ FeaturedResources.addView("activeResources", function (terms: FeaturedResourcesV
     },
     options: {
       limit: 5,
-    }
+    },
   }
 });


### PR DESCRIPTION
We are randomly selecting a resource to show in the banner, but because we do server-side rendering there is the possibility that the server will randomly select a different resource than the client, causing problems. This PR wraps that selection inside of a `useEffect`, removing the problem.

I think the correct way to handle this is by having Mongo only return one resource selected at random, but Mongo only allows random selection in aggregation pipelines and Vulcan does not seem to allow aggregation pipelines in views. If someone knows that either of those statements are false, I would appreciate learning it.

Also, this has some whitespace changes. I tried to mess with my editor to avoid this but it wasn't immediately working and I figured it wasn't the best use of time since we aren't going to get merge conflicts in this file anyway.