### PR TITLE
change groups to use a star icon

### DIFF
--- a/packages/lesswrong/components/localGroups/CommunityHome.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityHome.tsx
@@ -102,7 +102,7 @@ const CommunityHome = ({classes}: {
     const title = forumTypeSetting.get() === 'EAForum' ? 'Groups and Events' : 'Welcome to the Community Section';
     const WelcomeText = () => (isEAForum ?
     <Typography variant="body2" className={classes.welcomeText}>
-      <p>On the map above you can find nearby events (blue pin icons) and local groups (green people icons).</p>
+      <p>On the map above you can find nearby events (blue pin icons) and local groups (green star icons).</p>
       <p>This page is being trialed with a handful of EA groups, so the map isn't yet fully populated.
       For more, visit the <a className={classes.link} href="https://eahub.org/groups?utm_source=forum.effectivealtruism.org&utm_medium=Organic&utm_campaign=Forum_Homepage">EA Hub Groups Directory</a>.</p>
     </Typography> : 

--- a/packages/lesswrong/components/localGroups/CommunityMapFilter.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMapFilter.tsx
@@ -11,7 +11,7 @@ import VisibilityIcon from '@material-ui/icons/VisibilityOff';
 import EmailIcon from '@material-ui/icons/Email';
 import AddIcon from '@material-ui/icons/Add';
 import RoomIcon from '@material-ui/icons/Room';
-import MUIGroup from '@material-ui/icons/Group';
+import StarIcon from '@material-ui/icons/Star';
 import Tooltip from '@material-ui/core/Tooltip';
 import withDialog from '../common/withDialog'
 import withUser from '../common/withUser';
@@ -248,7 +248,7 @@ class CommunityMapFilter extends Component<CommunityMapFilterProps,CommunityMapF
     const { classes, openDialog, currentUser, showHideMap, toggleGroups, showGroups, toggleEvents, showEvents, toggleIndividuals, showIndividuals, history } = this.props;
   
     const isEAForum = forumTypeSetting.get() === 'EAForum';
-    const GroupIcon = () => isEAForum ? <MUIGroup className={classes.eaButtonIcon}/> : <GroupIconSVG className={classes.buttonIcon}/>;
+    const GroupIcon = () => isEAForum ? <StarIcon className={classes.eaButtonIcon}/> : <GroupIconSVG className={classes.buttonIcon}/>;
     const EventIcon = () => isEAForum ? <RoomIcon  className={classes.eaButtonIcon}/> : <ArrowSVG className={classes.buttonIcon}/>;
 
     const isAdmin = userIsAdmin(currentUser);

--- a/packages/lesswrong/components/localGroups/LocalGroupMarker.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupMarker.tsx
@@ -3,7 +3,7 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { GroupIconSVG } from './Icons'
 import { Marker } from 'react-map-gl';
 import { createStyles } from '@material-ui/core/styles';
-import MUIGroup from '@material-ui/icons/Group';
+import StarIcon from '@material-ui/icons/Star';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
@@ -37,7 +37,7 @@ const LocalGroupMarker = ({ group, handleMarkerClick, handleInfoWindowClose, inf
   const htmlBody = {__html: html};
 
   const GroupIcon = () =>  forumTypeSetting.get() === 'EAForum' ? 
-    <MUIGroup className={classes.eaIcon}/> : <GroupIconSVG className={classes.icon}/>;
+    <StarIcon className={classes.eaIcon}/> : <GroupIconSVG className={classes.icon}/>;
 
   return <React.Fragment>
     <Marker


### PR DESCRIPTION
All the dots from the heads on the map on prod are triggering my trypophobia so I'm changing the icon for groups to be a star. This probably looks better anyway.

<img width="800" alt="Screen Shot 2021-10-21 at 1 17 02 AM" src="https://user-images.githubusercontent.com/9057804/138215786-f745b3ae-8d28-4590-be0d-d78de049b7f1.png">
