### PR TITLE
Add reading time to post analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "LessWrong",
+  "name": "lesswrong",
   "version": "2.1.0",
   "scripts": {
     "postinstall": "scripts/postinstall.sh",

--- a/packages/lesswrong/components/common/AnalyticsPageInitializer.tsx
+++ b/packages/lesswrong/components/common/AnalyticsPageInitializer.tsx
@@ -122,16 +122,16 @@ function useCountUpTimer (incrementsInSeconds=[10, 30], switchIncrement=60) {
     }
 
     useEffect(() => {
-        if (timerIsActive) {
-            const  increment = (seconds < switchIncrement ) ? smallIncrementInSeconds : largeIncrementInSeconds
-            intervalTimer.current = setInterval(() => {
-              setSeconds(seconds + increment)
-              captureEvent("timerEvent", {seconds: seconds + increment, increment: increment})
-            }, increment*1000) //setInterval uses milliseconds
-        } else if (!timerIsActive && seconds !== 0) {
-            clearInterval(intervalTimer.current)
-        }
-        return () => clearInterval(intervalTimer.current)
+      if (timerIsActive) {
+        const  increment = (seconds < switchIncrement ) ? smallIncrementInSeconds : largeIncrementInSeconds
+        intervalTimer.current = setInterval(() => {
+          setSeconds(seconds + increment)
+          captureEvent("timerEvent", {seconds: seconds + increment, increment: increment})
+        }, increment*1000) //setInterval uses milliseconds
+      } else if (!timerIsActive && seconds !== 0) {
+        clearInterval(intervalTimer.current)
+      }
+      return () => clearInterval(intervalTimer.current)
     }, [timerIsActive, setTimerIsActive, seconds, captureEvent, smallIncrementInSeconds, largeIncrementInSeconds, switchIncrement])
 
     return { seconds, isActive: timerIsActive, setTimerIsActive, reset }

--- a/packages/lesswrong/components/posts/PostsAnalyticsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsAnalyticsPage.tsx
@@ -132,6 +132,10 @@ const PostsAnalyticsInner = ({ classes, post }: { classes: ClassesType, post: Po
           </TableCell>
         </TableRow>
         <TableRow>
+          <TableCell>{'Views by unique devices > 5 minutes'}</TableCell>
+          <TableCell>{postAnalytics?.uniqueClientViews5Min}</TableCell>
+        </TableRow>
+        <TableRow>
           <TableCell><LWTooltip title='Note: includes time spent reading and writing comments'>
             Median reading time
           </LWTooltip></TableCell>

--- a/packages/lesswrong/components/posts/PostsAnalyticsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsAnalyticsPage.tsx
@@ -17,6 +17,20 @@ import { Legend, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } f
 import  theme  from '../../themes/forumTheme'
 import moment from 'moment'
 
+function caclulateBounceRate(totalViews?: number, viewsAfter10sec?: number) {
+  if (!totalViews || !viewsAfter10sec) return null
+  return `${Math.round((1 - (viewsAfter10sec / totalViews)) * 100)} %`
+}
+
+function readableReadingTime (seconds?: number) {
+  if (!seconds) return null
+  const minutes = Math.floor(seconds / 60)
+  const secondsRemainder = seconds % 60
+  const secondsPart = `${secondsRemainder} s`
+  if (minutes > 0) return `${minutes} m ${secondsRemainder ? secondsPart : ''}`
+  return secondsPart
+}
+
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
     [theme.breakpoints.down('sm')]: {
@@ -78,7 +92,8 @@ function PostsAnalyticsGraphs (
 
 const PostsAnalyticsInner = ({ classes, post }: { classes: ClassesType, post: PostsPage }) => {
   const { postAnalytics, loading, error } = usePostAnalytics(post._id)
-  const { Loading, Typography } = Components
+  const { Loading, Typography, LWTooltip } = Components
+  
   if (loading) {
     return <>
       <Typography variant="body1" className={classNames(classes.gutterBottom, classes.calculating)}>
@@ -109,8 +124,18 @@ const PostsAnalyticsInner = ({ classes, post }: { classes: ClassesType, post: Po
           <TableCell>{postAnalytics?.uniqueClientViews}</TableCell>
         </TableRow>
         <TableRow>
-          <TableCell>{'Views by unique devices, on page for > 10 sec'}</TableCell>
-          <TableCell>{postAnalytics?.uniqueClientViews10Sec}</TableCell>
+          <TableCell><LWTooltip title='Percent of (unique) views that left before 10 seconds'>
+            Bounce Rate
+          </LWTooltip></TableCell>
+          <TableCell>
+            {caclulateBounceRate(postAnalytics?.uniqueClientViews, postAnalytics?.uniqueClientViews10Sec)}
+          </TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell><LWTooltip title='Note: includes time spent reading and writing comments'>
+            Median reading time
+          </LWTooltip></TableCell>
+          <TableCell>{readableReadingTime(postAnalytics?.medianReadingTime)}</TableCell>
         </TableRow>
       </TableBody>
     </Table>

--- a/packages/lesswrong/components/posts/usePostAnalytics.ts
+++ b/packages/lesswrong/components/posts/usePostAnalytics.ts
@@ -4,6 +4,7 @@ export type PostAnalyticsResult = {
   allViews: number
   uniqueClientViews: number
   uniqueClientViews10Sec: number
+  uniqueClientViews5Min: number
   medianReadingTime: number
   uniqueClientViewsSeries: {date: Date, uniqueClientViews: number}[]
 }
@@ -20,6 +21,7 @@ export const usePostAnalytics = (postId: string) => {
         uniqueClientViews
         uniqueClientViews10Sec
         medianReadingTime
+        uniqueClientViews5Min
         uniqueClientViewsSeries {
           date
           uniqueClientViews

--- a/packages/lesswrong/components/posts/usePostAnalytics.ts
+++ b/packages/lesswrong/components/posts/usePostAnalytics.ts
@@ -4,6 +4,7 @@ export type PostAnalyticsResult = {
   allViews: number
   uniqueClientViews: number
   uniqueClientViews10Sec: number
+  medianReadingTime: number
   uniqueClientViewsSeries: {date: Date, uniqueClientViews: number}[]
 }
 
@@ -18,6 +19,7 @@ export const usePostAnalytics = (postId: string) => {
         allViews
         uniqueClientViews
         uniqueClientViews10Sec
+        medianReadingTime
         uniqueClientViewsSeries {
           date
           uniqueClientViews

--- a/packages/lesswrong/lib/analyticsEvents.tsx
+++ b/packages/lesswrong/lib/analyticsEvents.tsx
@@ -8,6 +8,7 @@ import { ColorHash } from './vendor/colorHash';
 import { DatabasePublicSetting } from './publicSettings';
 import { getPublicSettingsLoaded } from './settingsCache';
 import * as _ from 'underscore';
+import moment from 'moment';
 
 const showAnalyticsDebug = new DatabasePublicSetting<"never"|"dev"|"always">("showAnalyticsDebug", "dev");
 
@@ -320,6 +321,10 @@ function browserConsoleLogAnalyticsEvent(event: any, rateLimitExceeded: boolean)
   for (let fieldName of Object.keys(event.props)) {
     c.log(`${fieldName}:`, event.props[fieldName]);
   }
+  // Timestamp recorded on the server will differ. Obviously in part because of
+  // the latency of the network, but also because we have a queue that we only
+  // flush max once/second.
+  c.log('[[time of day]]', moment().format('HH:mm:ss.SSS'));
   c.groupEnd();
 }
 
@@ -328,7 +333,10 @@ function serverConsoleLogAnalyticsEvent(event: any) {
   const colorEscapeSeq = `\x1b[38;2;0;${r};${g};${b}m`;
   const endColorEscapeSeq = '\x1b[0m';
   // eslint-disable-next-line no-console
-  console.log(`Analytics event: ${colorEscapeSeq}${event.type}${endColorEscapeSeq}`, event.props);
+  console.log(`Analytics event: ${colorEscapeSeq}${event.type}${endColorEscapeSeq}`, {
+    ...event.props,
+    '[[time of day]]': moment().format('HH:mm:ss.SSS')
+  });
 }
 
 Globals.captureEvent = captureEvent;

--- a/packages/lesswrong/server/resolvers/analyticsResolvers.ts
+++ b/packages/lesswrong/server/resolvers/analyticsResolvers.ts
@@ -76,8 +76,9 @@ const queries: QueryFunc[] = [
   makePgAnalyticsQueryScalar({
     query: `
       SELECT
-        count(*) AS unique_client_views_10_sec,
-        PERCENTILE_CONT(0.5) WITHIN GROUP(ORDER BY total_reading_time) AS median_reading_time
+        COUNT(*) AS unique_client_views_10_sec,
+        PERCENTILE_CONT(0.5) WITHIN GROUP(ORDER BY total_reading_time) AS median_reading_time,
+        COUNT(*) FILTER (WHERE total_reading_time > 5*60) AS unique_client_views_5_min
       FROM (
         SELECT
           client_id,
@@ -88,7 +89,11 @@ const queries: QueryFunc[] = [
         GROUP BY client_id
       ) a
     `,
-    resultColumns: ["unique_client_views_10_sec", "median_reading_time"]
+    resultColumns: [
+      "unique_client_views_10_sec",
+      "median_reading_time",
+      "unique_client_views_5_min"
+    ]
   }),
   makePgAnalyticsQuerySeries({
     // a masterpiece
@@ -167,6 +172,7 @@ addGraphQLSchema(`
     uniqueClientViews: Int
     uniqueClientViews10Sec: Int
     medianReadingTime: Int
+    uniqueClientViews5Min: Int
     uniqueClientViewsSeries: [UniqueClientViewsSeries]
   }
 `);


### PR DESCRIPTION
See upcoming post in slack about rational for trusting timerEvent times.

This PR addresses feedback from Brian Tan and Linch Zhang about what data they'd be interested in. Namely:

* I convert the <10seconds stat into a bounce rate percentage
* I add # of viewers >5 minutes. (I'd like to do >80% of estimated reading time, but that was a bit hard)
* I add median reading time 🎉 

![image](https://user-images.githubusercontent.com/10352319/138266459-760696a4-7d78-42a8-be48-8faed3bc82d0.png)

Also while investigating the reliability of timerEvent, I added the timestamp to our logging.

Also I changed the time of the package in package.json so my package.json validator would stop yelling at me about disallowed capitalization.