### PR TITLE
add redirect for old community path

### DIFF
--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -554,6 +554,16 @@ if (hasEventsSetting.get()) {
       getPingback: async (parsedUrl) => await getPostPingbackById(parsedUrl, parsedUrl.params._id),
     },
   );
+
+  if(isEAForum) {
+    addRoute(
+      {
+        name: "communityRedirect",
+        path:'/groupsAndEvents',
+        redirect: () => '/community'
+      }
+    );
+  }
 }
 
 addRoute(


### PR DESCRIPTION
Add a redirect bc an email went out with the old path. See https://cea-core.slack.com/archives/CB5D60VSB/p1635847627047000