### PR TITLE
display external event links on the event page

### DIFF
--- a/packages/lesswrong/components/localGroups/EventTime.tsx
+++ b/packages/lesswrong/components/localGroups/EventTime.tsx
@@ -28,13 +28,11 @@ const EventTime = ({post, dense=false}: {
   // Date and time formats
   const timeFormat = 'h:mm a z'; // 11:30 am PDT
   const dateFormat = getDateFormat(dense, isThisYear);
-  const dateAndTimeFormat = dateFormat+', '+timeFormat;
-  const calendarFormat = {sameElse : dateAndTimeFormat}
 
   // Alternate formats omitting the timezone, for the start time in a
   // start-end range.
   const startTimeFormat = 'h:mm a'; // 11:30 am
-  const startCalendarFormat = {sameElse: dateFormat+', '+startTimeFormat};
+  const calendarFormat = {sameElse: dateFormat+', '+startTimeFormat};
 
   // Neither start nor end time specified
   if (!start && !end) {
@@ -47,7 +45,7 @@ const EventTime = ({post, dense=false}: {
   // less sense, but users can enter silly things.)
   else if (!start || !end) {
     const eventTime = start ? start : end;
-    return <>{eventTime!.calendar({}, calendarFormat)}</>
+    return <>{eventTime!.calendar(calendarFormat)} {eventTime!.format('z')}</>
   }
   // Both start end end time specified
   else {
@@ -63,7 +61,7 @@ const EventTime = ({post, dense=false}: {
       </div>
     } else {
       return (<span>
-        {start.calendar({}, startCalendarFormat)} to {end.calendar({}, calendarFormat)}
+        {start.calendar({}, calendarFormat)} to {end.calendar({}, calendarFormat)} {end.format('z')}
       </span>);
     }
   }

--- a/packages/lesswrong/components/localGroups/GroupLinks.tsx
+++ b/packages/lesswrong/components/localGroups/GroupLinks.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib';
 import LinkIcon from '@material-ui/icons/Link';
 import SvgIcon from '@material-ui/core/SvgIcon';
-import IconButton from '@material-ui/core/IconButton';
 import Tooltip from '@material-ui/core/Tooltip';
 import { createStyles } from '@material-ui/core/styles';
 import { forumTypeSetting } from '../../lib/instanceSettings';
+import classNames from 'classnames';
 
 
 // just the "f", used for the FB Group link
@@ -88,6 +88,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     width: "17px",
     paddingTop: "0px",
     transform: "translateY(3px) rotate(-45deg)",
+    color: "rgba(0, 0, 0, 0.7)",
   },
 
   iconButton: {
@@ -95,6 +96,13 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     width: '18px',
     height: '18px',
     verticalAlign: "baseline",
+  },
+  
+  noMargin: {
+    margin: 0,
+    '& :first-child': {
+      marginLeft: 0
+    }
   }
 }));
 
@@ -105,8 +113,9 @@ const tooltips: Partial<Record<string,string>> = {
   'MIRIx': "This is a MIRIx group"
 }
 
-const GroupLinks = ({ document, classes }: {
+const GroupLinks = ({ document, noMargin, classes }: {
   document: localGroupsBase|PostsBase,
+  noMargin?: Boolean,
   classes: ClassesType,
 }) => {
   const isEAForum = forumTypeSetting.get() === 'EAForum';
@@ -115,7 +124,7 @@ const GroupLinks = ({ document, classes }: {
   
   return(
     <div className={classes.root}>
-      {!isEAForum && <div className={classes.groupTypes}>
+      {!isEAForum && <div className={noMargin ? classNames(classes.groupTypes, classes.noMargin) : classes.groupTypes}>
         {document.types && document.types.map(type => {
           return (
             <Tooltip
@@ -130,7 +139,7 @@ const GroupLinks = ({ document, classes }: {
           )
         })}
       </div>}
-      <div className={classes.groupLinks}>
+      <div className={(noMargin && (isEAForum || !document.types.length)) ? classNames(classes.groupLinks, classes.noMargin) : classes.groupLinks}>
         {document.facebookLink
           && <Tooltip
             title={`Link to Facebook ${isEvent ? 'Event' : 'Group'}`}

--- a/packages/lesswrong/components/localGroups/GroupLinks.tsx
+++ b/packages/lesswrong/components/localGroups/GroupLinks.tsx
@@ -34,6 +34,10 @@ export const MeetupIcon = (props: any) => <SvgIcon viewBox="15 15 70 70" {...pro
 </SvgIcon>
 
 const styles = createStyles((theme: ThemeType): JssStyles => ({
+  root: {
+    display: 'inline-block'
+  },
+
   groupTypes: {
     marginLeft: 12,
     display: 'inline-block',
@@ -51,7 +55,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   groupLinks: {
     display: 'inline-flex',
     alignItems: 'baseline',
-    marginLeft: '6px'
+    marginLeft: 6
   },
   
   groupLink: {
@@ -59,7 +63,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
   },
   
   websiteLink: {
-    marginLeft: theme.spacing.unit - 3
+    marginLeft: theme.spacing.unit - 2
   },
   
   facebookGroupIcon: {

--- a/packages/lesswrong/components/localGroups/GroupLinks.tsx
+++ b/packages/lesswrong/components/localGroups/GroupLinks.tsx
@@ -76,7 +76,7 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     display: "inline-block",
     color: "rgba(0, 0, 0, 0.7)",
     paddingTop: "0px",
-    transform: "translateY(1px)",
+    transform: "translateY(2px)",
   },
 
   linkIcon: {
@@ -136,7 +136,7 @@ const GroupLinks = ({ document, classes }: {
               <FacebookIcon className={classes.facebookGroupIcon}/>
             </a>
           </Tooltip>}
-        {document.facebookPageLink
+        {'facebookPageLink' in document && document.facebookPageLink
         && <Tooltip
           title={`Link to Facebook ${isEvent ? 'Event' : 'Page'}`}
           placement="top-end"

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageEventData.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageEventData.tsx
@@ -1,11 +1,39 @@
 import React from 'react'
 import { registerComponent, Components } from '../../../lib/vulcan-lib';
+import Tooltip from '@material-ui/core/Tooltip';
+import LinkIcon from '@material-ui/icons/Link';
+import { FacebookIcon, MeetupIcon } from '../../localGroups/GroupLinks';
 
 const styles = (theme: ThemeType): JssStyles => ({
   metadata: {
-    marginTop:theme.spacing.unit*2,
+    marginTop: theme.spacing.unit*2,
     ...theme.typography.postStyle,
     color: 'rgba(0,0,0,0.5)',
+  },
+  externalLinks: {
+    display: 'flex',
+    alignItems: 'baseline',
+    marginTop: theme.spacing.unit,
+  },
+  externalLink: {
+    marginRight: 20
+  },
+  facebookIcon: {
+    width: "15px",
+    height: "15px",
+    color: "rgba(0, 0, 0, 0.7)",
+  },
+  meetupIcon: {
+    width: "18px",
+    height: "18px",
+    color: "rgba(0, 0, 0, 0.7)",
+    transform: "translateY(2px)",
+  },
+  linkIcon: {
+    height: "20px",
+    width: "20px",
+    color: "rgba(0, 0, 0, 0.7)",
+    transform: "translateY(3px) rotate(-45deg)",
   },
 })
 
@@ -17,12 +45,48 @@ const PostsPageEventData = ({classes, post}: {
   
   const locationNode = onlineEvent ? (
     <div className={classes.eventLocation}>Online Event</div>
-  ) : location && <div className={classes.eventLocation}> {location} </div>;
+  ) : (location && <div className={classes.eventLocation}> {location} </div>);
+  
+  let externalLinks;
+  if (post.facebookLink || post.meetupLink || post.website) {
+    externalLinks = (
+      <div className={classes.externalLinks}>
+        {post.facebookLink && (
+          <Tooltip
+            title="See this event on Facebook"
+          >
+            <a href={post.facebookLink} className={classes.externalLink}>
+              <FacebookIcon className={classes.facebookIcon}/>
+            </a>
+          </Tooltip>
+        )}
+        {post.meetupLink && (
+          <Tooltip
+            title="See this event on Meetup"
+          >
+            <a href={post.meetupLink} className={classes.externalLink}>
+              <MeetupIcon className={classes.meetupIcon}/>
+            </a>
+          </Tooltip>
+        )}
+        {post.website && (
+          <Tooltip
+            title="See this event website"
+          >
+            <a href={post.website} className={classes.externalLink}>
+              <LinkIcon className={classes.linkIcon}/>
+            </a>
+          </Tooltip>
+        )}
+      </div>
+    )
+  }
   
   return <Components.Typography variant="body2" className={classes.metadata}>
       <div className={classes.eventTimes}> <Components.EventTime post={post} dense={false} /> </div>
       { locationNode }
       { contactInfo && <div className={classes.eventContact}> Contact: {contactInfo} </div> }
+      { externalLinks }
   </Components.Typography>
 }
 

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageEventData.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageEventData.tsx
@@ -1,40 +1,12 @@
 import React from 'react'
 import { registerComponent, Components } from '../../../lib/vulcan-lib';
-import Tooltip from '@material-ui/core/Tooltip';
-import LinkIcon from '@material-ui/icons/Link';
-import { FacebookIcon, MeetupIcon } from '../../localGroups/GroupLinks';
 
 const styles = (theme: ThemeType): JssStyles => ({
   metadata: {
     marginTop: theme.spacing.unit*2,
     ...theme.typography.postStyle,
     color: 'rgba(0,0,0,0.5)',
-  },
-  externalLinks: {
-    display: 'flex',
-    alignItems: 'baseline',
-    marginTop: theme.spacing.unit,
-  },
-  externalLink: {
-    marginRight: 20
-  },
-  facebookIcon: {
-    width: "15px",
-    height: "15px",
-    color: "rgba(0, 0, 0, 0.7)",
-  },
-  meetupIcon: {
-    width: "18px",
-    height: "18px",
-    color: "rgba(0, 0, 0, 0.7)",
-    transform: "translateY(2px)",
-  },
-  linkIcon: {
-    height: "20px",
-    width: "20px",
-    color: "rgba(0, 0, 0, 0.7)",
-    transform: "translateY(3px) rotate(-45deg)",
-  },
+  }
 })
 
 const PostsPageEventData = ({classes, post}: {
@@ -47,46 +19,10 @@ const PostsPageEventData = ({classes, post}: {
     <div className={classes.eventLocation}>Online Event</div>
   ) : (location && <div className={classes.eventLocation}> {location} </div>);
   
-  let externalLinks;
-  if (post.facebookLink || post.meetupLink || post.website) {
-    externalLinks = (
-      <div className={classes.externalLinks}>
-        {post.facebookLink && (
-          <Tooltip
-            title="See this event on Facebook"
-          >
-            <a href={post.facebookLink} className={classes.externalLink}>
-              <FacebookIcon className={classes.facebookIcon}/>
-            </a>
-          </Tooltip>
-        )}
-        {post.meetupLink && (
-          <Tooltip
-            title="See this event on Meetup"
-          >
-            <a href={post.meetupLink} className={classes.externalLink}>
-              <MeetupIcon className={classes.meetupIcon}/>
-            </a>
-          </Tooltip>
-        )}
-        {post.website && (
-          <Tooltip
-            title="See this event website"
-          >
-            <a href={post.website} className={classes.externalLink}>
-              <LinkIcon className={classes.linkIcon}/>
-            </a>
-          </Tooltip>
-        )}
-      </div>
-    )
-  }
-  
   return <Components.Typography variant="body2" className={classes.metadata}>
       <div className={classes.eventTimes}> <Components.EventTime post={post} dense={false} /> </div>
       { locationNode }
       { contactInfo && <div className={classes.eventContact}> Contact: {contactInfo} </div> }
-      { externalLinks }
   </Components.Typography>
 }
 

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -32,6 +32,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontSize: '1.4rem',
     fontFamily: theme.typography.uiSecondary.fontFamily,
   },
+  groupLinks: {
+    display: 'inline-block',
+    marginRight: 14
+  },
   commentsLink: {
     marginRight: SECONDARY_SPACING,
     color: theme.palette.grey[600],
@@ -148,7 +152,9 @@ const PostsPagePostHeader = ({post, classes}: {
           {!post.isEvent && <span className={classes.date}>
             <PostsPageDate post={post} hasMajorRevision={hasMajorRevision} />
           </span>}
-          {post.types && post.types.length > 0 && <Components.GroupLinks document={post} />}
+          {post.isEvent && <div className={classes.groupLinks}>
+            <Components.GroupLinks document={post} />
+          </div>}
           <a className={classes.commentsLink} href={"#comments"}>{ postGetCommentCountStr(post)}</a>
           <div className={classes.commentsLink}>
             <AddToCalendarIcon post={post} label="Add to Calendar" hideTooltip={true} />

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -34,7 +34,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   groupLinks: {
     display: 'inline-block',
-    marginRight: 14
+    marginRight: 20
   },
   commentsLink: {
     marginRight: SECONDARY_SPACING,
@@ -153,7 +153,7 @@ const PostsPagePostHeader = ({post, classes}: {
             <PostsPageDate post={post} hasMajorRevision={hasMajorRevision} />
           </span>}
           {post.isEvent && <div className={classes.groupLinks}>
-            <Components.GroupLinks document={post} />
+            <Components.GroupLinks document={post} noMargin={true} />
           </div>}
           <a className={classes.commentsLink} href={"#comments"}>{ postGetCommentCountStr(post)}</a>
           <div className={classes.commentsLink}>

--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -782,26 +782,12 @@ addFieldsDict(Posts, {
     viewableBy: ['guests'],
     insertableBy: ['members'],
     editableBy: [userOwns, 'sunshineRegiment', 'admins'],
-    label: "Facebook Group Event",
+    label: "Facebook Event",
     control: "MuiTextField",
     optional: true,
     group: formGroups.event,
     regEx: SimpleSchema.RegEx.Url,
-    tooltip: 'https://www.facebook.com/groups/...'
-  },
-  
-  facebookPageLink: {
-    type: String,
-    hidden: (props) => !props.eventForm,
-    viewableBy: ['guests'],
-    insertableBy: ['members'],
-    editableBy: [userOwns, 'sunshineRegiment', 'admins'],
-    label: "Facebook Page Event",
-    control: "MuiTextField",
-    optional: true,
-    group: formGroups.event,
-    regEx: SimpleSchema.RegEx.Url,
-    tooltip: 'https://www.facebook.com/...'
+    tooltip: 'https://www.facebook.com/events/...'
   },
   
   meetupLink: {

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -60,7 +60,6 @@ registerFragment(`
     localStartTime
     localEndTime
     facebookLink
-    facebookPageLink
     meetupLink
     website
     contactInfo

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -410,7 +410,6 @@ interface DbPost extends DbObject {
   location: string
   contactInfo: string
   facebookLink: string
-  facebookPageLink: string
   meetupLink: string
   website: string
   types: Array<string>

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -290,7 +290,6 @@ interface PostsBase extends PostsMinimumInfo { // fragment on Posts
   readonly localStartTime: Date,
   readonly localEndTime: Date,
   readonly facebookLink: string,
-  readonly facebookPageLink: string,
   readonly meetupLink: string,
   readonly website: string,
   readonly contactInfo: string,


### PR DESCRIPTION
We are already collecting external event page links (FB, Meetup, other site) for events, now we display them on the event page. I think most events will just have one of these three (but some will have multiple), so might look a little weird on its own line in practice - let me know if you have suggestions on where to put the icons.

I also fixed a small bug on the event page where we were not always showing the timezone.

<img width="711" alt="Screen Shot 2021-11-05 at 4 58 02 PM" src="https://user-images.githubusercontent.com/9057804/140578397-56fdcb23-1ba1-45c1-a387-97077c76107c.png">
<img width="383" alt="Screen Shot 2021-11-05 at 4 56 03 PM" src="https://user-images.githubusercontent.com/9057804/140578708-996912ea-33f2-415d-870f-785c4a6444cf.png">

